### PR TITLE
Extract Processor, add test suite

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,38 @@
+---
+version: 2
+jobs:
+  build:
+    docker:
+      - image: fpco/stack-build:lts-11.9
+      - image: contribsys/faktory
+        name: faktory
+    steps:
+      - checkout
+      - run:
+          name: Digest
+          command: |
+            git ls-files | xargs md5sum > digest
+      - restore_cache:
+          keys:
+            - v1-{{ .Branch }}-{{ checksum "digest" }}
+            - v1-{{ .Branch }}-
+            - v1-master-
+      - run:
+          name: Dependencies
+          command: make setup
+      - run:
+          name: Build
+          command: make build
+      - save_cache:
+          key: v1-{{ .Branch }}-{{ checksum "digest" }}
+          paths:
+            - ~/.stack
+            - ./.stack-work
+      - run:
+          name: Lint
+          command: make lint
+      - run:
+          name: Test
+          command: make test
+          environment:
+            FAKTORY_HOST: faktory

--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -1,0 +1,61 @@
+---
+- ignore: {name: "Redundant do", within: spec}
+- ignore: {name: "Eta reduce"}
+- ignore: {name: "Use list comprehension"}
+- ignore: {name: "Reduce duplication"}
+- ignore: {name: "Avoid restricted qualification", within: Faktory.Prelude}
+
+# Custom Warnings
+- warn: {lhs: fromJust, rhs: fromJustNote}
+- warn: {lhs: mapM, rhs: traverse}
+- warn: {lhs: mapM_, rhs: traverse_}
+- warn: {lhs: forM, rhs: for}
+- warn: {lhs: forM_, rhs: for_}
+
+# Specify additional command line arguments
+- arguments:
+  - -XBangPatterns
+  - -XDeriveAnyClass
+  - -XDeriveFoldable
+  - -XDeriveFunctor
+  - -XDeriveGeneric
+  - -XDeriveLift
+  - -XDeriveTraversable
+  - -XDerivingStrategies
+  - -XFlexibleContexts
+  - -XFlexibleInstances
+  - -XGADTs
+  - -XGeneralizedNewtypeDeriving
+  - -XLambdaCase
+  - -XMultiParamTypeClasses
+  - -XNoImplicitPrelude
+  - -XNoMonomorphismRestriction
+  - -XOverloadedStrings
+  - -XRankNTypes
+  - -XRecordWildCards
+  - -XScopedTypeVariables
+  - -XStandaloneDeriving
+  - -XTypeApplications
+  - -XTypeFamilies
+
+- modules:
+  - {name: [Data.Set], as: Set}
+  - {name: [Data.Map], as: Map}
+  - {name: [Data.HashSet], as: HashSet}
+  - {name: [Data.HashMap.Strict], as: HashMap}
+  - {name: [Data.Text], as: T}
+  - {name: [Data.Text.Encoding], as: T}
+  - {name: [Data.Text.IO], as: T}
+  - {name: [Data.Text.Lazy], as: TL}
+  - {name: [Data.Text.Lazy.Encoding], as: TL}
+  - {name: [Data.Text.IO.Lazy], as: TL}
+  - {name: [Data.ByteString], as: BS}
+  - {name: [Data.ByteString.Lazy], as: BSL}
+  - {name: [Data.ByteString.Char8], as: BS8}
+  - {name: [Data.ByteString.Lazy.Char8], as: BSL8}
+  - {name: [Data.List.NonEmpty], as: NE}
+  - {name: [Data.Sequence], as: Seq}
+
+- functions:
+  - {name: unsafePerformIO, within: []}  # never use unsafePerformIO
+  - {name: fromJustNote, within: []}  # cause warning on fromJustNote

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,24 @@
+all: setup build test lint
+
+.PHONY: setup
+setup:
+	stack setup
+	stack build --dependencies-only --test --no-run-tests
+	stack install hlint weeder
+
+.PHONY: build
+build:
+	stack build --fast --pedantic --test --no-run-tests
+
+.PHONY: test
+test:
+	stack build --fast --pedantic --test
+
+.PHONY: lint
+lint:
+	hlint .
+	weeder .
+
+.PHONY: clean
+clean:
+	stack clean

--- a/examples/consumer/Main.hs
+++ b/examples/consumer/Main.hs
@@ -3,10 +3,9 @@ module Main (main) where
 import Prelude
 
 import Control.Exception.Safe
-import Control.Monad
 import Data.Aeson
-import Faktory.Client
 import Faktory.Settings
+import Faktory.Worker
 import GHC.Generics
 
 -- | Must match examples/producer
@@ -15,9 +14,9 @@ newtype Job = Job { jobMessage :: String }
 instance FromJSON Job
 
 main :: IO ()
-main = withClient defaultSettings $ \client -> do
+main = do
   putStrLn "Starting consumer loop"
-  forever $ withJob client defaultQueue $ \job -> do
+  runWorker defaultSettings defaultQueue $ \job -> do
     let message = jobMessage job
 
     if message == "BOOM"

--- a/examples/producer/Main.hs
+++ b/examples/producer/Main.hs
@@ -2,6 +2,7 @@ module Main (main) where
 
 import Prelude
 
+import Control.Exception.Safe
 import Data.Aeson
 import Data.Semigroup ((<>))
 import Faktory.Client
@@ -15,13 +16,11 @@ newtype Job = Job { jobMessage :: String }
 instance ToJSON Job
 
 main :: IO ()
-main = withClient defaultSettings $ \client -> do
-  args <- getArgs
-  jobId <- pushJob
-    client
-    defaultQueue
-    Job
+main =
+  bracket (newClient defaultSettings Nothing) closeClient $ \client -> do
+    args <- getArgs
+    jobId <- pushJob client defaultQueue Job
       { jobMessage = unwords args
       }
 
-  putStrLn $ "Pushed job: " <> show jobId
+    putStrLn $ "Pushed job: " <> show jobId

--- a/library/Faktory/Client.hs
+++ b/library/Faktory/Client.hs
@@ -4,29 +4,23 @@ module Faktory.Client
     Client
   , newClient
   , closeClient
-  , withClient
 
   -- * High-level Job operations
   , pushJob
-  , withJob
-
-  -- * Low-level Job operations
-  , fetchJob
-  , ackJob
-  , failJob
 
   -- * High-level Client API
-  , command
-  , assertOK
+  , command_
+  , commandOK
+  , commandJSON
   ) where
 
 import Faktory.Prelude
 
+import Control.Concurrent.MVar
 import Data.Aeson
 import Data.Aeson.Casing
 import Data.ByteString.Lazy (ByteString, fromStrict)
 import qualified Data.ByteString.Lazy.Char8 as BSL8
-import qualified Data.Text as T
 import Faktory.Job
 import Faktory.Protocol
 import Faktory.Settings
@@ -37,10 +31,10 @@ import qualified Network.Socket as NS
 import qualified Network.Socket.ByteString as NSB
 import qualified Network.Socket.ByteString.Lazy as NSBL
 import System.Posix.Process (getProcessID)
-import System.Random
 
+-- | <https://github.com/contribsys/faktory/wiki/Worker-Lifecycle#initial-handshake>
 data HelloPayload = HelloPayload
-  { _hpWid :: String
+  { _hpWid :: Maybe WorkerId
   , _hpHostname :: HostName
   , _hpPid :: Integer -- TODO: Orphan ToJSON ProcessID
   , _hpLabels :: [String]
@@ -52,136 +46,90 @@ instance ToJSON HelloPayload where
    toJSON = genericToJSON $ aesonPrefix snakeCase
    toEncoding = genericToEncoding $ aesonPrefix snakeCase
 
--- Ruby uses 8 random hex
-randomWorkerId :: IO String
-randomWorkerId = take 8 . randomRs ('a', 'z') <$> newStdGen
-
-newtype AckPayload = AckPayload
-  { _apJid :: JobId
-  }
-  deriving Generic
-
-instance ToJSON AckPayload where
-   toJSON = genericToJSON $ aesonPrefix snakeCase
-   toEncoding = genericToEncoding $ aesonPrefix snakeCase
-
-data FailPayload = FailPayload
-  { _fpMessage :: Text
-  , _fpErrtype :: String
-  , _fpJid :: JobId
-  , _fpBacktrace :: [String]
-  }
-  deriving Generic
-
-instance ToJSON FailPayload where
-   toJSON = genericToJSON $ aesonPrefix snakeCase
-   toEncoding = genericToEncoding $ aesonPrefix snakeCase
-
 data Client = Client
-  { clientSocket :: NS.Socket
+  { clientSocket :: MVar NS.Socket
   , clientSettings :: Settings
   }
 
 -- | Open a new @'Client'@ connection with the given @'Settings'@
-newClient :: HasCallStack => Settings -> IO Client
-newClient settings@Settings{..} =
+newClient :: HasCallStack => Settings -> Maybe WorkerId -> IO Client
+newClient settings@Settings{..} mWorkerId =
   bracketOnError (connect settingsConnection) NS.close $ \sock -> do
-    let client = Client sock settings
+    -- TODO: HI { "v": 2 }
+    void $ recvUnsafe settings sock
 
-    helloPayload <- HelloPayload
-      <$> randomWorkerId
-      <*> (show <$> NS.getSocketName sock)
+    client <- Client
+      <$> newMVar sock
+      <*> pure settings
+
+    helloPayload <- HelloPayload mWorkerId
+      <$> (show <$> NS.getSocketName sock)
       <*> (toInteger <$> getProcessID)
       <*> pure ["haskell"]
       <*> pure 2
 
-    -- TODO: HI { "v": 2 }
-    void $ recvClient client
-    command client "HELLO" [encode helloPayload]
-    assertOK client
-
+    commandOK client "HELLO" [encode helloPayload]
     pure client
 
 -- | Close a @'Client'@
---
--- N.B. nothing prevents you from accidentally using a closed client. The
--- behavior when that happens is undefined. It's recommended you use
--- @'withClient'@ and never close a @'Client'@ yourself.
---
 closeClient :: Client -> IO ()
-closeClient client@Client{..} = do
-  command client "END" []
-  NS.close clientSocket
+closeClient Client{..} = withMVar clientSocket $ \sock -> do
+  sendUnsafe clientSettings sock "END" []
+  NS.close sock
 
--- | Open a new client, yield it, then close it
-withClient :: HasCallStack => Settings -> (Client -> IO ()) -> IO ()
-withClient settings = bracket (newClient settings) closeClient
-
-command :: Client -> ByteString -> [ByteString] -> IO ()
-command Client{..} cmd args =  do
-  let bs = BSL8.unwords (cmd:args)
-  settingsLogDebug clientSettings $ "> " <> show bs
-  void $ NSBL.send clientSocket (bs <> "\n")
-
-assertOK :: HasCallStack => Client -> IO ()
-assertOK client = do
-  let expected = Just "OK"
-  actual <- recvClient client
-  unless (actual == expected) $ throwString "Server not OK"
-
+-- | Push a Job to the Server
 pushJob :: (HasCallStack, ToJSON arg) => Client -> Queue -> arg -> IO JobId
 pushJob client queue arg = do
   job <- newJob queue arg
-  command client "PUSH" [encode job]
-  assertOK client
+  commandOK client "PUSH" [encode job]
   pure $ jobJid job
 
-withJob :: FromJSON arg => Client -> Queue -> (arg -> IO ()) -> IO ()
-withJob client queue f = do
-  mJob <- fetchJob client queue
+-- | Send a command, read and discard the response
+command_ :: Client -> ByteString -> [ByteString] -> IO ()
+command_ Client{..} cmd args = withMVar clientSocket $ \sock -> do
+  sendUnsafe clientSettings sock cmd args
+  void $ recvUnsafe clientSettings sock
 
-  for_ mJob $ \job ->
-    handleAny (failJob client job . T.pack . show) $ do
-      f $ jobArg job
-      ackJob client job
+-- | Send a command, assert the response is @OK@
+commandOK :: HasCallStack => Client -> ByteString -> [ByteString] -> IO ()
+commandOK Client{..} cmd args = withMVar clientSocket $ \sock -> do
+  sendUnsafe clientSettings sock cmd args
+  response <- recvUnsafe clientSettings sock
+  unless (response == Just "OK") $ throwString "Server not OK"
 
-fetchJob :: FromJSON args => Client -> Queue -> IO (Maybe (Job args))
-fetchJob client queue = do
-  command client "FETCH" [queueArg queue]
-  recvClientJSON client
+-- | Send a command, parse the response as JSON
+commandJSON :: FromJSON a => Client -> ByteString -> [ByteString] -> IO (Maybe a)
+commandJSON Client{..} cmd args = withMVar clientSocket $ \sock -> do
+  sendUnsafe clientSettings sock cmd args
+  mByteString <- recvUnsafe clientSettings sock
+  pure $ decode =<< mByteString
 
-ackJob :: HasCallStack => Client -> Job args -> IO ()
-ackJob client job = do
-  command client "ACK" [encode $ AckPayload $ jobJid job]
-  assertOK client
+-- | Send a command to the Server socket
+--
+-- Do not use outside of @'withMVar'@, this is not threadsafe.
+--
+sendUnsafe :: Settings -> NS.Socket -> ByteString -> [ByteString] -> IO ()
+sendUnsafe Settings{..} sock cmd args =  do
+  let bs = BSL8.unwords (cmd:args)
+  settingsLogDebug $ "> " <> show bs
+  void $ NSBL.send sock $ bs <> "\n"
 
-failJob :: HasCallStack => Client -> Job args -> Text -> IO ()
-failJob client job message = do
-  command client "FAIL" [encode $ FailPayload message "" (jobJid job) []]
-  assertOK client
-
-recvClient :: Client -> IO (Maybe ByteString)
-recvClient Client{..} = do
-  eByteString <- readReply readMore
-  settingsLogDebug clientSettings $ "< " <> show eByteString
+-- | Receive data from the Server socket
+--
+-- Do not use outside of @'withMVar'@, this is not threadsafe.
+--
+recvUnsafe :: Settings -> NS.Socket -> IO (Maybe ByteString)
+recvUnsafe Settings{..} sock = do
+  eByteString <- readReply $ NSB.recv sock 4096
+  settingsLogDebug $ "< " <> show eByteString
 
   case eByteString of
     Left err -> do
-      settingsLogError clientSettings err
+      settingsLogError err
       pure Nothing
     Right mByteString -> pure $ fromStrict <$> mByteString
- where
-  readMore = NSB.recv clientSocket 4096
-
--- | Receive data and decode it as JSON
---
--- Parse errors result in @'Nothing'@ (at the moment).
---
-recvClientJSON :: FromJSON a => Client -> IO (Maybe a)
-recvClientJSON = ((decode =<<) <$>) . recvClient
 
 -- | Connect to Host/Port
---
 connect :: Connection -> IO NS.Socket
 connect connection =
   bracketOnError open NS.close pure

--- a/library/Faktory/Job.hs
+++ b/library/Faktory/Job.hs
@@ -11,7 +11,7 @@ import Faktory.Prelude
 import Data.Aeson
 import Data.Aeson.Casing
 import Data.List.NonEmpty (NonEmpty)
-import qualified Data.List.NonEmpty as NonEmpty
+import qualified Data.List.NonEmpty as NE
 import Data.Time
 import Faktory.Settings (Queue)
 import GHC.Generics
@@ -44,7 +44,7 @@ newJob queue arg = do
     }
 
 jobArg :: Job arg -> arg
-jobArg Job{..} = NonEmpty.head jobArgs
+jobArg Job{..} = NE.head jobArgs
 
 instance ToJSON args => ToJSON (Job args) where
    toJSON = genericToJSON $ aesonPrefix snakeCase

--- a/library/Faktory/Protocol.hs
+++ b/library/Faktory/Protocol.hs
@@ -15,8 +15,8 @@ import Prelude hiding (error)
 
 import Data.ByteString (ByteString)
 import qualified Data.ByteString.Char8 as BS8
-import qualified Data.Text.Encoding as Text
-import qualified Data.Text.Read as Text
+import qualified Data.Text.Encoding as T
+import qualified Data.Text.Read as T
 import Scanner (Scanner)
 import qualified Scanner
 
@@ -67,7 +67,7 @@ bulk = Bulk <$> do
 integral :: Integral i => Scanner i
 integral = do
   str <- line
-  case Text.signed Text.decimal (Text.decodeUtf8 str) of
+  case T.signed T.decimal (T.decodeUtf8 str) of
     Left err -> fail (show err)
     Right (l, _) -> return l
 

--- a/library/Faktory/Settings.hs
+++ b/library/Faktory/Settings.hs
@@ -5,6 +5,8 @@ module Faktory.Settings
   , Queue
   , queueArg
   , defaultQueue
+  , WorkerId
+  , randomWorkerId
   ) where
 
 import Faktory.Prelude
@@ -15,6 +17,7 @@ import Data.String
 import Data.Text.Encoding (encodeUtf8)
 import Network.Socket (HostName, PortNumber)
 import System.IO (hPutStrLn, stderr)
+import System.Random
 
 data Connection = Connection
   { connectionHostName :: HostName
@@ -45,3 +48,9 @@ queueArg (Queue q) = fromStrict $ encodeUtf8 q
 
 defaultQueue :: Queue
 defaultQueue = "default"
+
+newtype WorkerId = WorkerId String
+  deriving newtype (FromJSON, ToJSON)
+
+randomWorkerId :: IO WorkerId
+randomWorkerId = WorkerId . take 8 . randomRs ('a', 'z') <$> newStdGen

--- a/library/Faktory/Worker.hs
+++ b/library/Faktory/Worker.hs
@@ -1,0 +1,101 @@
+-- | High-level interface for a Worker
+--
+-- Runs forever, @FETCH@-ing Jobs from the given Queue and handing each to your
+-- processing function.
+--
+module Faktory.Worker
+  ( WorkerHalt(..)
+  , runWorker
+  ) where
+
+import Faktory.Prelude
+
+import Control.Concurrent
+import Data.Aeson
+import Data.Aeson.Casing
+import qualified Data.Text as T
+import Faktory.Client
+import Faktory.Job
+import Faktory.Settings
+import GHC.Generics
+import GHC.Stack
+
+-- | If processing functions @'throw'@ this, @'runWorker'@ will exit
+data WorkerHalt = WorkerHalt
+  deriving (Eq, Show, Exception)
+
+newtype BeatPayload = BeatPayload
+  { _bpWid :: WorkerId
+  }
+  deriving Generic
+
+instance ToJSON BeatPayload where
+   toJSON = genericToJSON $ aesonPrefix snakeCase
+   toEncoding = genericToEncoding $ aesonPrefix snakeCase
+
+newtype AckPayload = AckPayload
+  { _apJid :: JobId
+  }
+  deriving Generic
+
+instance ToJSON AckPayload where
+   toJSON = genericToJSON $ aesonPrefix snakeCase
+   toEncoding = genericToEncoding $ aesonPrefix snakeCase
+
+data FailPayload = FailPayload
+  { _fpMessage :: Text
+  , _fpErrtype :: String
+  , _fpJid :: JobId
+  , _fpBacktrace :: [String]
+  }
+  deriving Generic
+
+instance ToJSON FailPayload where
+   toJSON = genericToJSON $ aesonPrefix snakeCase
+   toEncoding = genericToEncoding $ aesonPrefix snakeCase
+
+runWorker :: FromJSON args => Settings -> Queue -> (args -> IO ()) -> IO ()
+runWorker settings queue f = do
+  workerId <- randomWorkerId
+  client <- newClient settings $ Just workerId
+  beatThreadId <- forkIO $ forever $ heartBeat client workerId
+
+  forever (processorLoop client queue f)
+    `catch` (\(_ex :: WorkerHalt) -> pure ())
+    `finally` (killThread beatThreadId >> closeClient client)
+
+processorLoop :: FromJSON arg => Client -> Queue -> (arg -> IO ()) -> IO ()
+processorLoop client queue f = do
+  let
+    processAndAck job = do
+      f $ jobArg job
+      ackJob client job
+
+  mJob <- fetchJob client queue
+
+  for_ mJob $ \job ->
+    processAndAck job `catches`
+      [ Handler $ \(ex :: WorkerHalt) -> throw ex
+      , Handler $ \(ex :: SomeException) -> failJob client job $ T.pack $ show ex
+      ]
+
+-- | <https://github.com/contribsys/faktory/wiki/Worker-Lifecycle#heartbeat>
+heartBeat :: Client -> WorkerId -> IO ()
+heartBeat client workerId = do
+  threadDelay $ 25 * 1000000
+  command_ client "BEAT" [encode $ BeatPayload workerId]
+
+fetchJob :: FromJSON args => Client -> Queue -> IO (Maybe (Job args))
+fetchJob client queue =
+  -- Treat an exception here like no Job. The Client will have already logged
+  -- the protocol error to stderr, and we should just keep chugging.
+  handleAny (const $ pure Nothing)
+    $ commandJSON client "FETCH" [queueArg queue]
+
+ackJob :: HasCallStack => Client -> Job args -> IO ()
+ackJob client job =
+  commandOK client "ACK" [encode $ AckPayload $ jobJid job]
+
+failJob :: HasCallStack => Client -> Job args -> Text -> IO ()
+failJob client job message =
+  commandOK client "FAIL" [encode $ FailPayload message "" (jobJid job) []]

--- a/package.yaml
+++ b/package.yaml
@@ -48,7 +48,6 @@ library:
     - aeson
     - aeson-casing
     - bytestring
-    - hostname
     - network
     - random
     - safe-exceptions
@@ -64,6 +63,7 @@ executables:
     dependencies:
       - aeson
       - faktory
+      - safe-exceptions
 
   faktory-example-consumer:
     main: Main.hs
@@ -72,3 +72,12 @@ executables:
       - aeson
       - faktory
       - safe-exceptions
+
+tests:
+  hspec:
+    main: Spec.hs
+    source-dirs: tests
+    ghc-options: -rtsopts -O0
+    dependencies:
+      - faktory
+      - hspec

--- a/tests/FaktorySpec.hs
+++ b/tests/FaktorySpec.hs
@@ -1,0 +1,46 @@
+module FaktorySpec
+  ( spec
+  ) where
+
+import Faktory.Prelude
+
+import Control.Concurrent.MVar
+import Data.Maybe
+import Faktory.Client
+import Faktory.Settings
+import Faktory.Worker
+import System.Environment
+import Test.Hspec
+
+spec :: Spec
+spec = describe "Faktory" $ do
+  it "can push and process jobs" $ do
+    settings <- getTestSettings
+    bracket (newClient settings Nothing) closeClient $ \client -> do
+      void $ pushJob @Text client defaultQueue "a"
+      void $ pushJob @Text client defaultQueue "b"
+      void $ pushJob @Text client defaultQueue "HALT"
+
+    processedJobs <- newMVar ([] :: [Text])
+    runWorker settings defaultQueue $ \job -> do
+      modifyMVar_ processedJobs $ pure . (job:)
+      when (job == "HALT") $ throw WorkerHalt
+
+    jobs <- readMVar processedJobs
+    jobs `shouldMatchList` ["a", "b", "HALT"]
+
+-- TODO: Add proper, complete FAKTORY_URL support, as per Faktory documentation
+getTestSettings :: IO Settings
+getTestSettings = do
+  mFaktoryHost <- lookupEnv "FAKTORY_HOST"
+
+  let
+    defaultConnection = settingsConnection defaultSettings
+    defaultHostName = connectionHostName defaultConnection
+
+    testHostName = fromMaybe defaultHostName mFaktoryHost
+    testConnection = defaultConnection
+      { connectionHostName = testHostName
+      }
+
+  pure defaultSettings { settingsConnection = testConnection }

--- a/tests/Spec.hs
+++ b/tests/Spec.hs
@@ -1,0 +1,1 @@
+{-# OPTIONS_GHC -F -pgmF hspec-discover #-}


### PR DESCRIPTION
- Extract Faktory.Processor.runProcessor

  This is better high-level interface for consumers. After a similar extraction
  on the Push side, we can probably consider most of this library internal.

  Closes #3

- Remove withClient

  For the Processor side, Client life-cycle is managed internally in
  runProcessor. For the Push-side, it's more likely applications will want to
  do it themselves (e.g. to hold a Client in a Reader env), and if they do want
  the bracket-like behavior, it's easy enough to do (see the updated example).

- Add an end-to-end test & CI

  There is a glaring TODO here where the test might've uncovered a bug. I can't
  explain the behavior (yet), it works fine when I run the things manually.

  I'll keep investigating.

  Closes #2.