### PR TITLE
Stop hiding Left results in recvUnsafe

### DIFF
--- a/library/Faktory/Client.hs
+++ b/library/Faktory/Client.hs
@@ -114,9 +114,7 @@ newClient settings@Settings {..} mWorkerId =
 
     commandOK client "HELLO" [encode helloPayload]
     pure client
- where
-  fromJustThrows message = maybe (throwString message) pure
-  fromRightThrows = either throwString pure
+  where fromJustThrows message = maybe (throwString message) pure
 
 -- | Close a @'Client'@
 closeClient :: Client -> IO ()
@@ -139,7 +137,7 @@ flush client = commandOK client "FLUSH" []
 command_ :: Client -> ByteString -> [ByteString] -> IO ()
 command_ Client {..} cmd args = withMVar clientConnection $ \conn -> do
   sendUnsafe clientSettings conn cmd args
-  void $ recvUnsafe clientSettings conn
+  void $ fromRightThrows =<< recvUnsafe clientSettings conn
 
 -- | Send a command, assert the response is @OK@
 commandOK :: HasCallStack => Client -> ByteString -> [ByteString] -> IO ()

--- a/library/Faktory/Client.hs
+++ b/library/Faktory/Client.hs
@@ -20,6 +20,7 @@ import Faktory.Prelude
 import Control.Concurrent.MVar
 import Crypto.Hash (Digest, SHA256(..), hashWith)
 import Data.Aeson
+import Data.Bitraversable (bimapM)
 import Data.ByteArray (ByteArrayAccess)
 import Data.ByteString.Lazy (ByteString, fromStrict)
 import qualified Data.ByteString.Lazy.Char8 as BSL8
@@ -180,7 +181,7 @@ recvUnsafe :: Settings -> Connection -> IO (Either String (Maybe ByteString))
 recvUnsafe Settings {..} conn = do
   emByteString <- readReply $ connectionGet conn 4096
   settingsLogDebug $ "< " <> show emByteString
-  either (pure . Left) (pure . Right . fmap fromStrict) emByteString
+  bimapM pure (pure . fmap fromStrict) emByteString
 
 -- | Iteratively apply a function @n@ times
 --

--- a/library/Faktory/Prelude.hs
+++ b/library/Faktory/Prelude.hs
@@ -20,3 +20,6 @@ forkIOWithThrowToParent :: IO () -> IO ThreadId
 forkIOWithThrowToParent action = do
   parent <- myThreadId
   forkIO $ action `X.catchAny` \err -> throwTo parent err
+
+fromRightThrows :: MonadThrow m => Either String a -> m a
+fromRightThrows = either throwString pure


### PR DESCRIPTION
**Reviewers note**: the PR description is the first commit. Two other commits
come back with minor refactors. The overall diff is fine, but reviewing the
commits separately (with attention paid really only to the first) might be
easier.

Previously, when this function was unable to parse a Reply from Faktory, it
would log it and return a `Nothing`. This takes what should be a serious error
and replaces it by something innocuous-looking or even expected.

In general, `recvUnsafe` shouldn't make the assumption that its callers don't
care about the `Left`s and are fine with the log+`Nothing` handling it's been
taking internally. Concretely, the ramifications depend on use-case:

In `command_`, the return value from `recvUnsafe` is completely discarded,
things will appear successful when they very much were not. That is not changed
by this commit, but maintaining the information of the error beyond `recvUnsafe`
is required to fix it next.

In `commandOK`, we want to include failure information in the error we throw.
Again, this requires `recvUnsafe` not destroy that information internally.

In `commandJSON` as used by `fetchJob`, a `Nothing` represents no Job ready and
that the Worker should idle and loop. Masking failures as no Job here is mostly
fine, but handling the Left with log+ignore here, vs internally in `recvUnsafe`,
is at least better in principle.

It's worth noting that the "unsafe" in `recvUnsafe`'s naming is referring to
thread-safety, and not anything to do with handling failures, or any lack
thereof.