### PR TITLE
Extract a Producer abstraction

### DIFF
--- a/README.lhs
+++ b/README.lhs
@@ -49,7 +49,7 @@ details.
 ```haskell
 import Data.Aeson
 import Prelude
-import Faktory.Client
+import Faktory.Producer
 import Faktory.Job
 import Faktory.Settings
 import Faktory.Worker
@@ -57,9 +57,9 @@ import GHC.Generics
 
 {- Don't actually run anything -}
 main :: IO ()
-main = if True then pure () else (workerMain >> clientMain)
+main = if True then pure () else (workerMain >> producerMain)
 workerMain :: IO ()
-clientMain :: IO ()
+producerMain :: IO ()
 ```
 -->
 
@@ -91,19 +91,19 @@ workerMain = do
     -- unless you catch-and-rethrow them yourself.
 ```
 
-### Client
+### Producer
+
+`Producer` wraps `Client` for push-only usage.
 
 ```haskell
-clientMain = do
-  settings <- envSettings
-  client <- newClient settings Nothing -- N.B. A WorkerId is not necessary if
-                                       -- only pushing Jobs.
+producerMain = do
+  producer <- newProducerEnv
 
-  jobId <- perform mempty client $ MyJob "Hello world"
+  jobId <- perform mempty producer $ MyJob "Hello world"
 
   print jobId
 
-  closeClient client
+  closeProducer producer
 ```
 
 ### Configuration

--- a/examples/producer/Main.hs
+++ b/examples/producer/Main.hs
@@ -4,9 +4,8 @@ import Prelude
 
 import Control.Exception.Safe
 import Data.Aeson
-import Faktory.Client
 import Faktory.Job (perform)
-import Faktory.Settings
+import Faktory.Producer
 import GHC.Generics
 import System.Environment (getArgs)
 
@@ -16,10 +15,8 @@ newtype Job = Job { jobMessage :: String }
   deriving anyclass ToJSON
 
 main :: IO ()
-main = do
-  settings <- envSettings
-  bracket (newClient settings Nothing) closeClient $ \client -> do
-    args <- getArgs
-    jobId <- perform mempty client Job { jobMessage = unwords args }
+main = bracket newProducerEnv closeProducer $ \producer -> do
+  args <- getArgs
+  jobId <- perform mempty producer Job { jobMessage = unwords args }
 
-    putStrLn $ "Pushed job: " <> show jobId
+  putStrLn $ "Pushed job: " <> show jobId

--- a/library/Faktory/Client.hs
+++ b/library/Faktory/Client.hs
@@ -5,10 +5,6 @@ module Faktory.Client
   , newClient
   , closeClient
 
-  -- * High-level Job operations
-  , pushJob
-  , flush
-
   -- * High-level Client API
   , command_
   , commandOK
@@ -121,17 +117,6 @@ closeClient :: Client -> IO ()
 closeClient Client {..} = withMVar clientConnection $ \conn -> do
   sendUnsafe clientSettings conn "END" []
   connectionClose conn
-
--- | Push a Job to the Server
-pushJob :: (HasCallStack, ToJSON a) => Client -> a -> IO ()
-pushJob client job = commandOK client "PUSH" [encode job]
-
--- | Clear all job data in the Faktory server
---
--- Use with caution!
---
-flush :: HasCallStack => Client -> IO ()
-flush client = commandOK client "FLUSH" []
 
 -- | Send a command, read and discard the response
 command_ :: Client -> ByteString -> [ByteString] -> IO ()

--- a/library/Faktory/Job.hs
+++ b/library/Faktory/Job.hs
@@ -21,7 +21,7 @@ import Data.Aeson.Casing
 import Data.List.NonEmpty (NonEmpty)
 import qualified Data.List.NonEmpty as NE
 import Data.Time
-import Faktory.Client (Client, pushJob)
+import Faktory.Producer (Producer, pushJob)
 import Faktory.Settings (Queue)
 import GHC.Generics
 import GHC.Stack
@@ -65,10 +65,11 @@ newtype JobOptions = JobOptions [JobUpdate]
 -- 'perform' ('in_' 10 <> 'retry' 3) SomeJob
 -- @
 --
-perform :: (HasCallStack, ToJSON arg) => JobOptions -> Client -> arg -> IO JobId
-perform options client arg = do
+perform
+  :: (HasCallStack, ToJSON arg) => JobOptions -> Producer -> arg -> IO JobId
+perform options producer arg = do
   job <- applyOptions options =<< newJob arg
-  jobJid job <$ pushJob client job
+  jobJid job <$ pushJob producer job
 
 applyOptions :: JobOptions -> Job arg -> IO (Job arg)
 applyOptions (JobOptions patches) = go patches

--- a/library/Faktory/Producer.hs
+++ b/library/Faktory/Producer.hs
@@ -1,0 +1,40 @@
+module Faktory.Producer
+  ( Producer
+  , newProducer
+  , newProducerEnv
+  , closeProducer
+  , pushJob
+  , flush
+  )
+where
+
+import Faktory.Prelude
+
+import Data.Aeson
+import Faktory.Client
+import Faktory.Settings
+import GHC.Stack
+
+newtype Producer = Producer
+  { producerClient :: Client
+  }
+
+newProducer :: Settings -> IO Producer
+newProducer settings = Producer <$> newClient settings Nothing
+
+newProducerEnv :: IO Producer
+newProducerEnv = newProducer =<< envSettings
+
+closeProducer :: Producer -> IO ()
+closeProducer = closeClient . producerClient
+
+-- | Push a Job to the Server
+pushJob :: (HasCallStack, ToJSON a) => Producer -> a -> IO ()
+pushJob producer job = commandOK (producerClient producer) "PUSH" [encode job]
+
+-- | Clear all job data in the Faktory server
+--
+-- Use with caution!
+--
+flush :: HasCallStack => Producer -> IO ()
+flush producer = commandOK (producerClient producer) "FLUSH" []


### PR DESCRIPTION
This adds a layer over Client for usage as a Producer (pushing Jobs
only). This is an initial step in clarifying Settings, Worker, and
Client for typical usage. See #49 for context.