### PR TITLE
Separate WorkerSettings, configurable WorkerId

### DIFF
--- a/README.lhs
+++ b/README.lhs
@@ -115,6 +115,8 @@ When using `envSettings`, the following variables will be used:
 When using `envWorkerSettings`, the following variables are also used:
 
 - `FAKTORY_QUEUE`: the name of the queue to consume from. Default is "default".
+- `FAKTORY_WORKER_ID`: the Id to use for this Worker. Default is to assign a
+  random one.
 
 ## Examples
 

--- a/README.lhs
+++ b/README.lhs
@@ -81,8 +81,9 @@ newtype MyJob = MyJob
 ```haskell
 workerMain = do
   settings <- envSettings
+  workerSettings <- envWorkerSettings
 
-  runWorker settings $ \job ->
+  runWorker settings workerSettings $ \job ->
     -- Process your Job here
     putStrLn $ myJobMessage job
 
@@ -110,13 +111,15 @@ producerMain = do
 
 When using `envSettings`, the following variables will be used:
 
-- `FAKTORY_QUEUE`: the name of the queue to consume from. This is Worker-only,
-  for `perform`, a non-default Queue should be given by the `queue` option
 - `FAKTORY_PROVIDER`: the name of another environment variable where the
   connection string can be found. Defaults to `FAKTORY_URL`.
 - `FAKTORY_URL` (or whatever you named in `FAKTORY_PROVIDER`): connection string
   to the Faktory server. Format is `tcp(+tls)://(:password@)host:port`. Defaults
   to `tcp://localhost:4719`.
+
+When using `envWorkerSettings`, the following variable is also used:
+
+- `FAKTORY_QUEUE`: the name of the queue to consume from.
 
 ## Examples
 

--- a/README.lhs
+++ b/README.lhs
@@ -51,7 +51,6 @@ import Data.Aeson
 import Prelude
 import Faktory.Producer
 import Faktory.Job
-import Faktory.Settings
 import Faktory.Worker
 import GHC.Generics
 
@@ -79,17 +78,13 @@ newtype MyJob = MyJob
 ### Worker
 
 ```haskell
-workerMain = do
-  settings <- envSettings
-  workerSettings <- envWorkerSettings
+workerMain = runWorkerEnv $ \job ->
+  -- Process your Job here
+  putStrLn $ myJobMessage job
 
-  runWorker settings workerSettings $ \job ->
-    -- Process your Job here
-    putStrLn $ myJobMessage job
-
-    -- If any exception is thrown, the job will be marked as Failed in Faktory
-    -- and retried. Note: you will not otherwise hear about any such exceptions,
-    -- unless you catch-and-rethrow them yourself.
+  -- If any exception is thrown, the job will be marked as Failed in Faktory
+  -- and retried. Note: you will not otherwise hear about any such exceptions,
+  -- unless you catch-and-rethrow them yourself.
 ```
 
 ### Producer
@@ -117,9 +112,9 @@ When using `envSettings`, the following variables will be used:
   to the Faktory server. Format is `tcp(+tls)://(:password@)host:port`. Defaults
   to `tcp://localhost:4719`.
 
-When using `envWorkerSettings`, the following variable is also used:
+When using `envWorkerSettings`, the following variables are also used:
 
-- `FAKTORY_QUEUE`: the name of the queue to consume from.
+- `FAKTORY_QUEUE`: the name of the queue to consume from. Default is "default".
 
 ## Examples
 

--- a/examples/consumer/Main.hs
+++ b/examples/consumer/Main.hs
@@ -4,7 +4,6 @@ import Prelude
 
 import Control.Exception.Safe
 import Data.Aeson
-import Faktory.Settings
 import Faktory.Worker
 import GHC.Generics
 
@@ -16,9 +15,7 @@ newtype Job = Job { jobMessage :: String }
 main :: IO ()
 main = do
   putStrLn "Starting consumer loop"
-  settings <- envSettings
-  workerSettings <- envWorkerSettings
-  runWorker settings workerSettings $ \job -> do
+  runWorkerEnv $ \job -> do
     let message = jobMessage job
 
     if message == "BOOM"

--- a/examples/consumer/Main.hs
+++ b/examples/consumer/Main.hs
@@ -17,7 +17,8 @@ main :: IO ()
 main = do
   putStrLn "Starting consumer loop"
   settings <- envSettings
-  runWorker settings $ \job -> do
+  workerSettings <- envWorkerSettings
+  runWorker settings workerSettings $ \job -> do
     let message = jobMessage job
 
     if message == "BOOM"

--- a/library/Faktory/Settings.hs
+++ b/library/Faktory/Settings.hs
@@ -50,18 +50,24 @@ envSettings = do
 
 data WorkerSettings = WorkerSettings
   { settingsQueue :: Queue
+  , settingsId :: Maybe WorkerId
   , settingsIdleDelay :: Int
   }
 
 defaultWorkerSettings :: WorkerSettings
-defaultWorkerSettings =
-  WorkerSettings { settingsQueue = defaultQueue, settingsIdleDelay = 1 }
+defaultWorkerSettings = WorkerSettings
+  { settingsQueue = defaultQueue
+  , settingsId = Nothing
+  , settingsIdleDelay = 1
+  }
 
 envWorkerSettings :: IO WorkerSettings
 envWorkerSettings = do
   mQueue <- lookupEnv "FAKTORY_QUEUE"
+  mWorkerId <- lookupEnv "FAKTORY_WORKER_ID"
   pure defaultWorkerSettings
     { settingsQueue = maybe defaultQueue (Queue . pack) mQueue
+    , settingsId = WorkerId <$> mWorkerId
     }
 
 newtype Queue = Queue Text

--- a/library/Faktory/Worker.hs
+++ b/library/Faktory/Worker.hs
@@ -60,7 +60,7 @@ instance ToJSON FailPayload where
 runWorker
   :: FromJSON args => Settings -> WorkerSettings -> (args -> IO ()) -> IO ()
 runWorker settings workerSettings f = do
-  workerId <- randomWorkerId
+  workerId <- maybe randomWorkerId pure $ settingsId workerSettings
   client <- newClient settings $ Just workerId
   beatThreadId <- forkIOWithThrowToParent $ forever $ heartBeat client workerId
 

--- a/library/Faktory/Worker.hs
+++ b/library/Faktory/Worker.hs
@@ -6,6 +6,7 @@
 module Faktory.Worker
   ( WorkerHalt(..)
   , runWorker
+  , runWorkerEnv
   )
 where
 
@@ -66,6 +67,12 @@ runWorker settings workerSettings f = do
   forever (processorLoop client settings workerSettings f)
     `catch` (\(_ex :: WorkerHalt) -> pure ())
     `finally` (killThread beatThreadId >> closeClient client)
+
+runWorkerEnv :: FromJSON args => (args -> IO ()) -> IO ()
+runWorkerEnv f = do
+  settings <- envSettings
+  workerSettings <- envWorkerSettings
+  runWorker settings workerSettings f
 
 processorLoop
   :: FromJSON arg


### PR DESCRIPTION
Changes:

- ecb74ad (patrick brisbin, 6 minutes ago)
   Add WorkerId to WorkerSettings

   Closes #47.

- f12c3a4 (patrick brisbin, 10 minutes ago)
   Add runWorkerEnv

- 315aa03 (patrick brisbin, 13 minutes ago)
   Separate WorkerSettings from Settings

   Settings are generic to Producer or Worker (connection info, logging 
   hooks). WorkerSettings are specific to Workers (queue, delay).

   This increases the surface area of runWorker for now, which we may seek to
   resolve later.