### PR TITLE
Add support for queue namespacing

### DIFF
--- a/README.lhs
+++ b/README.lhs
@@ -112,7 +112,7 @@ When using `envSettings`, the following variables will be used:
   to the Faktory server. Format is
   `tcp(+tls)://(:password@)host:port(/namespace)`. Defaults to
   `tcp://localhost:4719`. `namespace` is prependend to queue names on job
-  submission.
+  submission and worker consumption.
 
 When using `envWorkerSettings`, the following variables are also used:
 

--- a/README.lhs
+++ b/README.lhs
@@ -109,8 +109,10 @@ When using `envSettings`, the following variables will be used:
 - `FAKTORY_PROVIDER`: the name of another environment variable where the
   connection string can be found. Defaults to `FAKTORY_URL`.
 - `FAKTORY_URL` (or whatever you named in `FAKTORY_PROVIDER`): connection string
-  to the Faktory server. Format is `tcp(+tls)://(:password@)host:port`. Defaults
-  to `tcp://localhost:4719`.
+  to the Faktory server. Format is
+  `tcp(+tls)://(:password@)host:port(/namespace)`. Defaults to
+  `tcp://localhost:4719`. `namespace` is prependend to queue names on job
+  submission.
 
 When using `envWorkerSettings`, the following variables are also used:
 

--- a/library/Faktory/Client.hs
+++ b/library/Faktory/Client.hs
@@ -1,7 +1,7 @@
 module Faktory.Client
   (
   -- * Client operations
-    Client
+    Client(..)
   , newClient
   , closeClient
 

--- a/library/Faktory/Connection.hs
+++ b/library/Faktory/Connection.hs
@@ -107,4 +107,4 @@ parseConnection = go <?> "tcp(+tls)://(:<password>@)<host>:<port>(/namespace)"
       <*> manyTill anySingle (char ':')
       <*> (read <$> some digitChar)
       <*> (toNamespace <$> optional (char '/' *> some anySingle))
-  toNamespace = Namespace . pack . fromMaybe ""
+  toNamespace = Namespace . maybe "" pack

--- a/library/Faktory/Connection.hs
+++ b/library/Faktory/Connection.hs
@@ -30,6 +30,7 @@ data ConnectionInfo = ConnectionInfo
   , connectionInfoPassword :: Maybe String
   , connectionInfoHostName :: HostName
   , connectionInfoPort :: PortNumber
+  , connectionInfoNamespace :: Maybe String
   }
   deriving stock (Eq, Show)
 
@@ -39,6 +40,7 @@ defaultConnectionInfo = ConnectionInfo
   , connectionInfoPassword = Nothing
   , connectionInfoHostName = "localhost"
   , connectionInfoPort = 7419
+  , connectionInfoNamespace = Nothing
   }
 
 -- | Parse a @'Connection'@ from environment variables
@@ -46,7 +48,7 @@ defaultConnectionInfo = ConnectionInfo
 -- > FAKTORY_PROVIDER=FAKTORY_URL
 -- > FAKTORY_URL=tcp://:my-password@localhost:7419
 --
--- Supported format is @tcp(+tls):\/\/(:password@)host:port@.
+-- Supported format is @tcp(+tls):\/\/(:password@)host:port(/namespace)@.
 --
 -- See <https://github.com/contribsys/faktory/wiki/Worker-Lifecycle#url-configuration>.
 --
@@ -92,7 +94,7 @@ parseProvider =
   some (upperChar <|> char '_') <?> "an environment variable name"
 
 parseConnection :: Parser ConnectionInfo
-parseConnection = go <?> "tcp(+tls)://(:<password>@)<host>:<port>"
+parseConnection = go <?> "tcp(+tls)://(:<password>@)<host>:<port>(/namespace)"
  where
   go =
     ConnectionInfo
@@ -100,3 +102,4 @@ parseConnection = go <?> "tcp(+tls)://(:<password>@)<host>:<port>"
       <*> optional (char ':' *> manyTill anySingle (char '@'))
       <*> manyTill anySingle (char ':')
       <*> (read <$> some digitChar)
+      <*> optional (char '/' *> some anySingle)

--- a/library/Faktory/Job.hs
+++ b/library/Faktory/Job.hs
@@ -20,7 +20,6 @@ import Data.Aeson
 import Data.Aeson.Casing
 import Data.List.NonEmpty (NonEmpty)
 import qualified Data.List.NonEmpty as NE
-import Data.Maybe (fromMaybe)
 import Data.Time
 import Faktory.Client (Client(..))
 import Faktory.Producer (Producer(..), pushJob)
@@ -79,15 +78,14 @@ perform options producer arg = do
   job <- applyOptions namespace options =<< newJob arg
   jobJid job <$ pushJob producer job
 
-applyOptions :: Maybe String -> JobOptions -> Job arg -> IO (Job arg)
+applyOptions :: Namespace -> JobOptions -> Job arg -> IO (Job arg)
 applyOptions namespace (JobOptions patches) = go patches
  where
-  queuePrefix = pack $ fromMaybe "" namespace
-  namespaceQueue (Queue q) = Queue $ mappend queuePrefix q
   go [] job = pure job
   go (set : sets) job = case set of
     SetRetry n -> go sets $ job { jobRetry = Just n }
-    SetQueue q -> go sets $ job { jobQueue = Just $ namespaceQueue q }
+    SetQueue q ->
+      go sets $ job { jobQueue = Just $ namespaceQueue namespace q }
     SetJobtype jt -> go sets $ job { jobJobtype = jt }
     SetAt time -> go sets $ job { jobAt = Just time }
     SetIn diff -> do

--- a/library/Faktory/Job.hs
+++ b/library/Faktory/Job.hs
@@ -20,9 +20,11 @@ import Data.Aeson
 import Data.Aeson.Casing
 import Data.List.NonEmpty (NonEmpty)
 import qualified Data.List.NonEmpty as NE
+import Data.Maybe (fromMaybe)
 import Data.Time
-import Faktory.Producer (Producer, pushJob)
-import Faktory.Settings (Queue)
+import Faktory.Client (Client(..))
+import Faktory.Producer (Producer(..), pushJob)
+import Faktory.Settings
 import GHC.Generics
 import GHC.Stack
 import System.Random
@@ -68,16 +70,24 @@ newtype JobOptions = JobOptions [JobUpdate]
 perform
   :: (HasCallStack, ToJSON arg) => JobOptions -> Producer -> arg -> IO JobId
 perform options producer arg = do
-  job <- applyOptions options =<< newJob arg
+  let
+    namespace =
+      connectionInfoNamespace
+        $ settingsConnection
+        $ clientSettings
+        $ producerClient producer
+  job <- applyOptions namespace options =<< newJob arg
   jobJid job <$ pushJob producer job
 
-applyOptions :: JobOptions -> Job arg -> IO (Job arg)
-applyOptions (JobOptions patches) = go patches
+applyOptions :: Maybe String -> JobOptions -> Job arg -> IO (Job arg)
+applyOptions namespace (JobOptions patches) = go patches
  where
+  queuePrefix = pack $ fromMaybe "" namespace
+  namespaceQueue (Queue q) = Queue $ mappend queuePrefix q
   go [] job = pure job
   go (set : sets) job = case set of
     SetRetry n -> go sets $ job { jobRetry = Just n }
-    SetQueue q -> go sets $ job { jobQueue = Just q }
+    SetQueue q -> go sets $ job { jobQueue = Just $ namespaceQueue q }
     SetJobtype jt -> go sets $ job { jobJobtype = jt }
     SetAt time -> go sets $ job { jobAt = Just time }
     SetIn diff -> do

--- a/library/Faktory/Producer.hs
+++ b/library/Faktory/Producer.hs
@@ -1,5 +1,5 @@
 module Faktory.Producer
-  ( Producer
+  ( Producer(..)
   , newProducer
   , newProducerEnv
   , closeProducer

--- a/library/Faktory/Settings.hs
+++ b/library/Faktory/Settings.hs
@@ -6,6 +6,7 @@ module Faktory.Settings
   , defaultWorkerSettings
   , envWorkerSettings
   , Queue(..)
+  , namespaceQueue
   , queueArg
   , defaultQueue
   , WorkerId
@@ -13,6 +14,7 @@ module Faktory.Settings
 
   -- * Re-exports
   , ConnectionInfo(..)
+  , Namespace(..)
   ) where
 
 import Faktory.Prelude
@@ -72,6 +74,9 @@ envWorkerSettings = do
 
 newtype Queue = Queue Text
   deriving newtype (IsString, FromJSON, ToJSON)
+
+namespaceQueue :: Namespace -> Queue -> Queue
+namespaceQueue (Namespace n) (Queue q) = Queue $ mappend n q
 
 queueArg :: Queue -> ByteString
 queueArg (Queue q) = fromStrict $ encodeUtf8 q

--- a/library/Faktory/Worker.hs
+++ b/library/Faktory/Worker.hs
@@ -83,11 +83,13 @@ processorLoop
   -> IO ()
 processorLoop client settings workerSettings f = do
   let
+    namespace = connectionInfoNamespace $ settingsConnection settings
     processAndAck job = do
       f $ jobArg job
       ackJob client job
 
-  emJob <- fetchJob client $ settingsQueue workerSettings
+  emJob <- fetchJob client $ namespaceQueue namespace $ settingsQueue
+    workerSettings
 
   case emJob of
     Left err -> settingsLogError settings $ "Invalid Job: " <> err

--- a/tests/Faktory/ConnectionSpec.hs
+++ b/tests/Faktory/ConnectionSpec.hs
@@ -30,6 +30,7 @@ spec = do
         connectionInfoPassword `shouldBe` Nothing
         connectionInfoHostName `shouldBe` "foo"
         connectionInfoPort `shouldBe` 123
+        connectionInfoNamespace `shouldBe` Nothing
 
     it "parses tls and password" $ do
       let
@@ -44,6 +45,19 @@ spec = do
         connectionInfoPassword `shouldBe` Just "foo"
         connectionInfoHostName `shouldBe` "bar"
         connectionInfoPort `shouldBe` 123
+
+    it "parses namespace" $ do
+      let
+        env =
+          [ ("FAKTORY_PROVIDER", Nothing)
+          , ("FAKTORY_URL", Just "tcp://localhost:7419/prefix")
+          ]
+
+      withEnvironment env $ do
+        ConnectionInfo {..} <- envConnectionInfo
+        connectionInfoHostName `shouldBe` "localhost"
+        connectionInfoPort `shouldBe` 7419
+        connectionInfoNamespace `shouldBe` Just "prefix"
 
     it "follows _PROVIDER to find _URL" $ do
       let

--- a/tests/Faktory/ConnectionSpec.hs
+++ b/tests/Faktory/ConnectionSpec.hs
@@ -30,7 +30,7 @@ spec = do
         connectionInfoPassword `shouldBe` Nothing
         connectionInfoHostName `shouldBe` "foo"
         connectionInfoPort `shouldBe` 123
-        connectionInfoNamespace `shouldBe` Nothing
+        connectionInfoNamespace `shouldBe` Namespace ""
 
     it "parses tls and password" $ do
       let
@@ -57,7 +57,7 @@ spec = do
         ConnectionInfo {..} <- envConnectionInfo
         connectionInfoHostName `shouldBe` "localhost"
         connectionInfoPort `shouldBe` 7419
-        connectionInfoNamespace `shouldBe` Just "prefix"
+        connectionInfoNamespace `shouldBe` Namespace "prefix"
 
     it "follows _PROVIDER to find _URL" $ do
       let


### PR DESCRIPTION
Namespacing is a powerful concept in multi-tenant infrastructure,
commonly supported as an entry in connection strings (e.g. setting
`dbname` when creating a [PG connection URI](https://www.postgresql.org/docs/10/libpq-connect.html)).

To support multi-tenant Faktory instances, namespacing can be easily
achieved by prefixing queue names with a provided namespace.

This PR provides for such an option by extending `FAKTORY_URL`
parsing and modifying job creation to prepend `namespace` to
any queue settings on the job.