### PR TITLE
BATCH support

### DIFF
--- a/README.lhs
+++ b/README.lhs
@@ -169,8 +169,9 @@ stack build --pedantic --test --no-run-tests
 stack build --pedantic --test
 ```
 
-*NOTE*: `FactorySpec` requires a local Faktory server is running, and it will
-flush all Jobs from this server as part of running the tests.
+- `FactorySpec` requires a local Faktory server is running, and it will flush
+  all Jobs from this server as part of running the tests.
+- The tests for `BATCH` require testing against an Enterprise Faktory image
 
 ---
 

--- a/library/Faktory/Ent/Batch.hs
+++ b/library/Faktory/Ent/Batch.hs
@@ -106,9 +106,10 @@ newBatch producer options = do
     "BATCH NEW"
     [encode options]
   case result of
-    Left err -> throwString $ "TODO: " <> err
-    Right Nothing -> throwString "TODO"
+    Left err -> batchNewError err
+    Right Nothing -> batchNewError "No BatchId returned"
     Right (Just bs) -> pure $ BatchId $ decodeUtf8 $ BSL.toStrict bs
+  where batchNewError err = throwString $ "BATCH NEW error: " <> err
 
 commitBatch :: Producer -> BatchId -> IO ()
 commitBatch producer (BatchId bid) = command_

--- a/library/Faktory/Ent/Batch.hs
+++ b/library/Faktory/Ent/Batch.hs
@@ -66,32 +66,20 @@ data BatchOptions arg = BatchOptions
   , boComplete :: Maybe (Last (Job arg))
   }
   deriving stock Generic
-  deriving Semigroup via GenericSemigroupMonoid (BatchOptions arg)
+  deriving (Semigroup, Monoid) via GenericSemigroupMonoid (BatchOptions arg)
 
 instance ToJSON arg => ToJSON (BatchOptions arg) where
   toJSON = genericToJSON $ aesonPrefix snakeCase
   toEncoding = genericToEncoding $ aesonPrefix snakeCase
 
 description :: Text -> BatchOptions arg
-description d = BatchOptions
-  { boDescription = Just $ Last d
-  , boSuccess = Nothing
-  , boComplete = Nothing
-  }
+description d = mempty { boDescription = Just $ Last d }
 
 complete :: Job arg -> BatchOptions arg
-complete job = BatchOptions
-  { boDescription = Nothing
-  , boSuccess = Nothing
-  , boComplete = Just $ Last job
-  }
+complete job = mempty { boComplete = Just $ Last job }
 
 success :: Job arg -> BatchOptions arg
-success job = BatchOptions
-  { boDescription = Nothing
-  , boSuccess = Just $ Last job
-  , boComplete = Nothing
-  }
+success job = mempty { boSuccess = Just $ Last job }
 
 runBatchT :: ToJSON arg => BatchOptions arg -> Producer -> BatchT a -> IO a
 runBatchT options producer (BatchT f) = do

--- a/library/Faktory/Ent/Batch.hs
+++ b/library/Faktory/Ent/Batch.hs
@@ -1,0 +1,129 @@
+{-# LANGUAGE DerivingVia #-}
+
+-- | Support for the @BATCH@ command (Enterprise only)
+--
+-- <https://github.com/contribsys/faktory/wiki/Ent-Batches>
+--
+-- Batches allow multiple Jobs to be enqueued as a group, with a description
+-- (visible in the admin UI) and Jobs attached to run on completion of all Jobs
+-- within the group (always, or only if all were successful).
+--
+-- Usage:
+--
+-- @
+-- -- Build a Job to run at completion of the Batch. Arguments are the same as
+-- -- you would pass to 'perform' the Job.
+-- onComplete <- buildJob mempty producer myJob
+--
+-- 'runBatchT' ('complete' onComplete <> 'description' "My Batch") producer $ do
+--   -- Use 'batchPerform' instead of 'perform'
+--   void $ 'batchPerform' mempty producer myBatchedJob1
+--   void $ 'batchPerform' mempty producer myBatchedJob2
+-- @
+--
+-- __/NOTE__: This module does not support batched Jobs dynamically adding more
+-- Jobs to the Batch. PRs welcome.
+--
+module Faktory.Ent.Batch
+    (
+    -- * Options
+      BatchOptions
+    , description
+    , complete
+    , success
+
+    -- * Running
+    , runBatchT
+    , BatchT
+    , batchPerform
+    )
+where
+
+import Faktory.Prelude
+
+import Control.Monad.Reader
+import Data.Aeson
+import Data.Aeson.Casing
+import Data.ByteString.Lazy as BSL
+import Data.Semigroup (Last(..))
+import Data.Semigroup.Generic
+import Data.Text.Encoding (decodeUtf8, encodeUtf8)
+import Faktory.Client
+import Faktory.Job
+import Faktory.Producer
+import GHC.Generics
+import GHC.Stack
+
+newtype BatchT a = BatchT (ReaderT BatchId IO a)
+  deriving newtype (Functor, Applicative, Monad, MonadIO, MonadReader BatchId)
+
+newtype BatchId = BatchId Text
+  deriving newtype ToJSON
+
+data BatchOptions arg = BatchOptions
+  { boDescription :: Maybe (Last Text)
+  , boSuccess :: Maybe (Last (Job arg))
+  , boComplete :: Maybe (Last (Job arg))
+  }
+  deriving stock Generic
+  deriving Semigroup via GenericSemigroupMonoid (BatchOptions arg)
+
+instance ToJSON arg => ToJSON (BatchOptions arg) where
+  toJSON = genericToJSON $ aesonPrefix snakeCase
+  toEncoding = genericToEncoding $ aesonPrefix snakeCase
+
+description :: Text -> BatchOptions arg
+description d = BatchOptions
+  { boDescription = Just $ Last d
+  , boSuccess = Nothing
+  , boComplete = Nothing
+  }
+
+complete :: Job arg -> BatchOptions arg
+complete job = BatchOptions
+  { boDescription = Nothing
+  , boSuccess = Nothing
+  , boComplete = Just $ Last job
+  }
+
+success :: Job arg -> BatchOptions arg
+success job = BatchOptions
+  { boDescription = Nothing
+  , boSuccess = Just $ Last job
+  , boComplete = Nothing
+  }
+
+runBatchT :: ToJSON arg => BatchOptions arg -> Producer -> BatchT a -> IO a
+runBatchT options producer (BatchT f) = do
+  bid <- newBatch producer options
+  result <- runReaderT f bid
+  result <$ commitBatch producer bid
+
+newtype CustomBatchId = CustomBatchId
+  { bid :: BatchId
+  }
+  deriving stock Generic
+  deriving anyclass ToJSON
+
+batchPerform
+  :: (HasCallStack, ToJSON arg) => JobOptions -> Producer -> arg -> BatchT JobId
+batchPerform options producer arg = do
+  bid <- ask
+  BatchT $ lift $ perform (custom (CustomBatchId bid) <> options) producer arg
+
+newBatch :: ToJSON arg => Producer -> BatchOptions arg -> IO BatchId
+newBatch producer options = do
+  result <- commandByteString
+    (producerClient producer)
+    "BATCH NEW"
+    [encode options]
+  case result of
+    Left err -> throwString $ "TODO: " <> err
+    Right Nothing -> throwString "TODO"
+    Right (Just bs) -> pure $ BatchId $ decodeUtf8 $ BSL.toStrict bs
+
+commitBatch :: Producer -> BatchId -> IO ()
+commitBatch producer (BatchId bid) = command_
+  (producerClient producer)
+  "BATCH COMMIT"
+  [BSL.fromStrict $ encodeUtf8 bid]

--- a/library/Faktory/Ent/Batch.hs
+++ b/library/Faktory/Ent/Batch.hs
@@ -97,7 +97,7 @@ batchPerform
   :: (HasCallStack, ToJSON arg) => JobOptions -> Producer -> arg -> BatchT JobId
 batchPerform options producer arg = do
   bid <- ask
-  BatchT $ lift $ perform (custom (CustomBatchId bid) <> options) producer arg
+  BatchT $ lift $ perform (options <> custom (CustomBatchId bid)) producer arg
 
 newBatch :: ToJSON arg => Producer -> BatchOptions arg -> IO BatchId
 newBatch producer options = do

--- a/library/Faktory/Job.hs
+++ b/library/Faktory/Job.hs
@@ -84,22 +84,18 @@ jobArg :: Job arg -> arg
 jobArg Job {..} = NE.head jobArgs
 
 instance ToJSON args => ToJSON (Job args) where
-  toJSON Job {..} = object
-    [ "jid" .= jobJid
-    , "at" .= jobAt
-    , "args" .= jobArgs
-    , "jobtype" .= joJobtype jobOptions
-    , "retry" .= joRetry jobOptions
-    , "queue" .= joQueue jobOptions
-    ]
-  toEncoding Job {..} = pairs $ mconcat
-    [ "jid" .= jobJid
-    , "at" .= jobAt
-    , "args" .= jobArgs
-    , "jobtype" .= joJobtype jobOptions
-    , "retry" .= joRetry jobOptions
-    , "queue" .= joQueue jobOptions
-    ]
+  toJSON = object . toPairs
+  toEncoding = pairs . mconcat . toPairs
+
+toPairs :: (KeyValue a, ToJSON arg) => Job arg -> [a]
+toPairs Job {..} =
+  [ "jid" .= jobJid
+  , "at" .= jobAt
+  , "args" .= jobArgs
+  , "jobtype" .= joJobtype jobOptions
+  , "retry" .= joRetry jobOptions
+  , "queue" .= joQueue jobOptions
+  ]
 
 -- brittany-disable-next-binding
 

--- a/library/Faktory/Job/Custom.hs
+++ b/library/Faktory/Job/Custom.hs
@@ -1,0 +1,26 @@
+-- | Wrapper for the schema-less 'Value' used for @custom@ in Job payloads
+--
+-- This type's 'Semigroup' will merge two Objects. It is right-biased, as we are
+-- generally throughout this library, so called /last-wins/ semantics.
+--
+module Faktory.Job.Custom
+    ( Custom
+    , toCustom
+    ) where
+
+import Faktory.Prelude
+
+import Data.Aeson
+import qualified Data.HashMap.Strict as HashMap
+
+newtype Custom = Custom Value
+  deriving stock (Eq, Show)
+  deriving newtype (FromJSON, ToJSON)
+
+toCustom :: ToJSON a => a -> Custom
+toCustom = Custom . toJSON
+
+instance Semigroup Custom where
+  (Custom (Object a)) <> (Custom (Object b)) =
+    Custom $ Object $ HashMap.union b a
+  _ <> b = b

--- a/library/Faktory/JobOptions.hs
+++ b/library/Faktory/JobOptions.hs
@@ -23,6 +23,7 @@ import Data.Aeson
 import Data.Semigroup (Last(..))
 import Data.Semigroup.Generic
 import Data.Time
+import Faktory.Job.Custom
 import Faktory.Settings (Namespace, Queue)
 import qualified Faktory.Settings as Settings
 import GHC.Generics
@@ -46,7 +47,7 @@ data JobOptions = JobOptions
   , joRetry :: Maybe (Last Int)
   , joQueue :: Maybe (Last Queue)
   , joSchedule :: Maybe (Last (Either UTCTime NominalDiffTime))
-  , joCustom :: Maybe (Last Value)
+  , joCustom :: Maybe Custom
   }
   deriving stock Generic
   deriving (Semigroup, Monoid) via GenericSemigroupMonoid JobOptions
@@ -92,4 +93,4 @@ in_ :: NominalDiffTime -> JobOptions
 in_ i = mempty { joSchedule = Just $ Last $ Right i }
 
 custom :: ToJSON a => a -> JobOptions
-custom v = mempty { joCustom = Just $ Last $ toJSON v }
+custom v = mempty { joCustom = Just $ toCustom v }

--- a/library/Faktory/JobOptions.hs
+++ b/library/Faktory/JobOptions.hs
@@ -10,6 +10,7 @@ module Faktory.JobOptions
   , jobtype
   , at
   , in_
+  , custom
 
   -- * Enqueue-time modifiers
   , getAtFromSchedule
@@ -45,6 +46,7 @@ data JobOptions = JobOptions
   , joRetry :: Maybe (Last Int)
   , joQueue :: Maybe (Last Queue)
   , joSchedule :: Maybe (Last (Either UTCTime NominalDiffTime))
+  , joCustom :: Maybe (Last Value)
   }
   deriving stock Generic
   deriving (Semigroup, Monoid) via GenericSemigroupMonoid JobOptions
@@ -58,6 +60,7 @@ instance FromJSON JobOptions where
       <*> o .:? "retry"
       <*> o .:? "queue"
       <*> (fmap (Last . Right) <$> o .:? "at")
+      <*> o .:? "custom"
 
 getAtFromSchedule :: JobOptions -> IO (Maybe UTCTime)
 getAtFromSchedule options = for (getLast <$> joSchedule options) $ \case
@@ -87,3 +90,6 @@ at t = mempty { joSchedule = Just $ Last $ Left t }
 
 in_ :: NominalDiffTime -> JobOptions
 in_ i = mempty { joSchedule = Just $ Last $ Right i }
+
+custom :: ToJSON a => a -> JobOptions
+custom v = mempty { joCustom = Just $ Last $ toJSON v }

--- a/package.yaml
+++ b/package.yaml
@@ -97,6 +97,7 @@ library:
     - cryptonite < 0.29
     - megaparsec < 9.1
     - memory
+    - mtl
     - network
     - random < 1.3
     - safe-exceptions

--- a/package.yaml
+++ b/package.yaml
@@ -106,6 +106,7 @@ library:
     - text > 1.2 && < 1.4
     - time < 1.12
     - unix
+    - unordered-containers
 
 executables:
   faktory-example-producer:
@@ -131,6 +132,7 @@ tests:
     ghc-options: -rtsopts
     dependencies:
       - faktory
+      - aeson
       - async
       - hspec
       - time

--- a/tests/Faktory/JobOptionsSpec.hs
+++ b/tests/Faktory/JobOptionsSpec.hs
@@ -4,6 +4,7 @@ module Faktory.JobOptionsSpec
 
 import Faktory.Prelude
 
+import Data.Aeson
 import Data.Semigroup (Last(..))
 import Data.Time
   ( DiffTime
@@ -14,6 +15,7 @@ import Data.Time
   , secondsToDiffTime
   )
 import Data.Time.Calendar (fromGregorian)
+import Faktory.Job.Custom
 import Faktory.JobOptions
 import Faktory.Settings (Namespace(..), Queue(..))
 import Test.Hspec
@@ -26,6 +28,23 @@ spec = do
         let options = retry 1 <> retry 2
 
         fmap getLast (joRetry options) `shouldBe` Just 2
+
+      it "merges custom fields" $ do
+        let
+          custom1 = object ["a" .= True, "b" .= True, "c" .= True]
+          custom2 = object ["a" .= False, "d" .= False]
+          options = custom custom1 <> custom custom2
+
+        joCustom options
+          `shouldBe` Just
+                       (toCustom
+                       $ object
+                           [ "a" .= False
+                           , "b" .= True
+                           , "c" .= True
+                           , "d" .= False
+                           ]
+                       )
 
     describe "getAtFromSchedule" $ do
       it "sets at based on in" $ do

--- a/tests/FaktorySpec.hs
+++ b/tests/FaktorySpec.hs
@@ -53,8 +53,8 @@ spec = describe "Faktory" $ do
         void $ runBatch (success c) producer $ do
           void $ batchPerform @Text mempty producer "a"
           void $ batchPerform @Text mempty producer "b"
-          -- Give a little time for Faktory to fire the callback
-          liftIO $ threadDelay 1000000
+        -- Give a little time for Faktory to fire the callback
+        liftIO $ threadDelay 500000
 
       jobs `shouldMatchList` ["a", "b", "c", "HALT"]
 
@@ -64,7 +64,7 @@ spec = describe "Faktory" $ do
         void $ runBatch (success c) producer $ do
           void $ batchPerform @Text mempty producer "BOOM"
           void $ batchPerform @Text mempty producer "b"
-          liftIO $ threadDelay 1000000
+        liftIO $ threadDelay 500000
 
       jobs `shouldMatchList` ["BOOM", "b", "HALT"]
 
@@ -74,7 +74,7 @@ spec = describe "Faktory" $ do
         void $ runBatch (complete c) producer $ do
           void $ batchPerform @Text mempty producer "a"
           void $ batchPerform @Text mempty producer "b"
-          liftIO $ threadDelay 1000000
+        liftIO $ threadDelay 500000
 
       jobs `shouldMatchList` ["a", "b", "c", "HALT"]
 
@@ -84,7 +84,7 @@ spec = describe "Faktory" $ do
         void $ runBatch (complete c) producer $ do
           void $ batchPerform @Text mempty producer "BOOM"
           void $ batchPerform @Text mempty producer "b"
-          liftIO $ threadDelay 1000000
+        liftIO $ threadDelay 500000
 
       jobs `shouldMatchList` ["BOOM", "b", "c", "HALT"]
 
@@ -96,12 +96,11 @@ spec = describe "Faktory" $ do
         void $ runBatch options producer $ do
           void $ batchPerform @Text mempty producer "a"
           void $ batchPerform @Text mempty producer "b"
-          liftIO $ threadDelay 1000000
+        liftIO $ threadDelay 500000
 
       jobs `shouldMatchList` ["a", "b", "d", "HALT"]
 
-    -- https://github.com/contribsys/faktory/issues/340
-    xit "runs success and complete if all Jobs were successful" $ do
+    it "runs success and complete if all Jobs were successful" $ do
       jobs <- workerTestCase $ \producer -> do
         c <- buildJob @Text mempty producer "c"
         d <- buildJob @Text mempty producer "d"
@@ -109,7 +108,7 @@ spec = describe "Faktory" $ do
         void $ runBatch options producer $ do
           void $ batchPerform @Text mempty producer "a"
           void $ batchPerform @Text mempty producer "b"
-          liftIO $ threadDelay 1000000
+        liftIO $ threadDelay 500000
 
       jobs `shouldMatchList` ["a", "b", "c", "d", "HALT"]
 

--- a/tests/FaktorySpec.hs
+++ b/tests/FaktorySpec.hs
@@ -50,7 +50,7 @@ spec = describe "Faktory" $ do
     it "runs a success job if all in-batch jobs succeed" $ do
       jobs <- workerTestCase $ \producer -> do
         c <- buildJob @Text mempty producer "c"
-        void $ runBatchT (success c) producer $ do
+        void $ runBatch (success c) producer $ do
           void $ batchPerform @Text mempty producer "a"
           void $ batchPerform @Text mempty producer "b"
           -- Give a little time for Faktory to fire the callback
@@ -61,7 +61,7 @@ spec = describe "Faktory" $ do
     it "does not run a success job if all jobs don't succeed" $ do
       jobs <- workerTestCase $ \producer -> do
         c <- buildJob @Text mempty producer "c"
-        void $ runBatchT (success c) producer $ do
+        void $ runBatch (success c) producer $ do
           void $ batchPerform @Text mempty producer "BOOM"
           void $ batchPerform @Text mempty producer "b"
           liftIO $ threadDelay 1000000
@@ -71,7 +71,7 @@ spec = describe "Faktory" $ do
     it "runs a job on complete" $ do
       jobs <- workerTestCase $ \producer -> do
         c <- buildJob @Text mempty producer "c"
-        void $ runBatchT (complete c) producer $ do
+        void $ runBatch (complete c) producer $ do
           void $ batchPerform @Text mempty producer "a"
           void $ batchPerform @Text mempty producer "b"
           liftIO $ threadDelay 1000000
@@ -81,7 +81,7 @@ spec = describe "Faktory" $ do
     it "runs a job on complete, even if in-batch jobs fail" $ do
       jobs <- workerTestCase $ \producer -> do
         c <- buildJob @Text mempty producer "c"
-        void $ runBatchT (complete c) producer $ do
+        void $ runBatch (complete c) producer $ do
           void $ batchPerform @Text mempty producer "BOOM"
           void $ batchPerform @Text mempty producer "b"
           liftIO $ threadDelay 1000000
@@ -93,7 +93,7 @@ spec = describe "Faktory" $ do
         c <- buildJob @Text mempty producer "c"
         d <- buildJob @Text mempty producer "d"
         let options = description "foo" <> success c <> success d
-        void $ runBatchT options producer $ do
+        void $ runBatch options producer $ do
           void $ batchPerform @Text mempty producer "a"
           void $ batchPerform @Text mempty producer "b"
           liftIO $ threadDelay 1000000
@@ -106,7 +106,7 @@ spec = describe "Faktory" $ do
         c <- buildJob @Text mempty producer "c"
         d <- buildJob @Text mempty producer "d"
         let options = description "foo" <> complete c <> success d
-        void $ runBatchT options producer $ do
+        void $ runBatch options producer $ do
           void $ batchPerform @Text mempty producer "a"
           void $ batchPerform @Text mempty producer "b"
           liftIO $ threadDelay 1000000

--- a/tests/FaktorySpec.hs
+++ b/tests/FaktorySpec.hs
@@ -7,6 +7,8 @@ import Faktory.Prelude
 import Control.Concurrent (threadDelay)
 import Control.Concurrent.Async
 import Control.Concurrent.MVar
+import Control.Monad.IO.Class (liftIO)
+import Faktory.Ent.Batch
 import Faktory.Job
 import Faktory.Producer
 import Faktory.Settings
@@ -44,6 +46,73 @@ spec = describe "Faktory" $ do
 
     jobs `shouldMatchList` ["HALT"]
 
+  context "BATCH" $ do
+    it "runs a success job if all in-batch jobs succeed" $ do
+      jobs <- workerTestCase $ \producer -> do
+        c <- buildJob @Text mempty producer "c"
+        void $ runBatchT (success c) producer $ do
+          void $ batchPerform @Text mempty producer "a"
+          void $ batchPerform @Text mempty producer "b"
+          -- Give a little time for Faktory to fire the callback
+          liftIO $ threadDelay 1000000
+
+      jobs `shouldMatchList` ["a", "b", "c", "HALT"]
+
+    it "does not run a success job if all jobs don't succeed" $ do
+      jobs <- workerTestCase $ \producer -> do
+        c <- buildJob @Text mempty producer "c"
+        void $ runBatchT (success c) producer $ do
+          void $ batchPerform @Text mempty producer "BOOM"
+          void $ batchPerform @Text mempty producer "b"
+          liftIO $ threadDelay 1000000
+
+      jobs `shouldMatchList` ["BOOM", "b", "HALT"]
+
+    it "runs a job on complete" $ do
+      jobs <- workerTestCase $ \producer -> do
+        c <- buildJob @Text mempty producer "c"
+        void $ runBatchT (complete c) producer $ do
+          void $ batchPerform @Text mempty producer "a"
+          void $ batchPerform @Text mempty producer "b"
+          liftIO $ threadDelay 1000000
+
+      jobs `shouldMatchList` ["a", "b", "c", "HALT"]
+
+    it "runs a job on complete, even if in-batch jobs fail" $ do
+      jobs <- workerTestCase $ \producer -> do
+        c <- buildJob @Text mempty producer "c"
+        void $ runBatchT (complete c) producer $ do
+          void $ batchPerform @Text mempty producer "BOOM"
+          void $ batchPerform @Text mempty producer "b"
+          liftIO $ threadDelay 1000000
+
+      jobs `shouldMatchList` ["BOOM", "b", "c", "HALT"]
+
+    it "combines duplicate options in last-wins fashion" $ do
+      jobs <- workerTestCase $ \producer -> do
+        c <- buildJob @Text mempty producer "c"
+        d <- buildJob @Text mempty producer "d"
+        let options = description "foo" <> success c <> success d
+        void $ runBatchT options producer $ do
+          void $ batchPerform @Text mempty producer "a"
+          void $ batchPerform @Text mempty producer "b"
+          liftIO $ threadDelay 1000000
+
+      jobs `shouldMatchList` ["a", "b", "d", "HALT"]
+
+    -- https://github.com/contribsys/faktory/issues/340
+    xit "runs success and complete if all Jobs were successful" $ do
+      jobs <- workerTestCase $ \producer -> do
+        c <- buildJob @Text mempty producer "c"
+        d <- buildJob @Text mempty producer "d"
+        let options = description "foo" <> complete c <> success d
+        void $ runBatchT options producer $ do
+          void $ batchPerform @Text mempty producer "a"
+          void $ batchPerform @Text mempty producer "b"
+          liftIO $ threadDelay 1000000
+
+      jobs `shouldMatchList` ["a", "b", "c", "d", "HALT"]
+
 workerTestCase :: HasCallStack => (Producer -> IO ()) -> IO [Text]
 workerTestCase = workerTestCaseWith id
 
@@ -62,6 +131,7 @@ workerTestCaseWith editSettings run = do
   processedJobs <- newMVar []
   a <- async $ runWorker settings workerSettings $ \job -> do
     modifyMVar_ processedJobs $ pure . (job :)
+    when (job == "BOOM") $ throw $ userError "BOOM"
     when (job == "HALT") $ throw WorkerHalt
 
   bracket newProducerEnv closeProducer $ \producer -> do


### PR DESCRIPTION
https://github.com/contribsys/faktory/wiki/Ent-Batches

Prerequisite changes include:

- Extract commandByteString

  Re-usable as a building-block and needed for BATCH NEW, which returns
  the Batch Id as a raw ByteString.

- Extract buildJob

  Kind of a weird interface, but the pair of applyOptions and newJob is
  needed so we can construct complete Jobs to include as hooks in the
  BATCH creation.

- Support custom in options and payload

  I'm leaving this an un-typed Value internally for now, but am open to
  giving it a schema based on the documentation.