### PR TITLE
Fix parsing of "at"

### DIFF
--- a/library/Faktory/JobOptions.hs
+++ b/library/Faktory/JobOptions.hs
@@ -60,7 +60,7 @@ instance FromJSON JobOptions where
       <$> o .:? "jobtype"
       <*> o .:? "retry"
       <*> o .:? "queue"
-      <*> (fmap (Last . Right) <$> o .:? "at")
+      <*> (fmap (Last . Left) <$> o .:? "at")
       <*> o .:? "custom"
 
 getAtFromSchedule :: JobOptions -> IO (Maybe UTCTime)

--- a/tests/FaktorySpec.hs
+++ b/tests/FaktorySpec.hs
@@ -8,6 +8,7 @@ import Control.Concurrent (threadDelay)
 import Control.Concurrent.Async
 import Control.Concurrent.MVar
 import Control.Monad.IO.Class (liftIO)
+import Data.Time (getCurrentTime)
 import Faktory.Ent.Batch
 import Faktory.Job
 import Faktory.Producer
@@ -30,6 +31,19 @@ spec = describe "Faktory" $ do
       void $ perform @Text (retry 0) producer "b"
 
     jobs `shouldMatchList` ["a", "b", "HALT"]
+
+  it "can push Jobs to run at a given time" $ do
+    now <- getCurrentTime
+    jobs <- workerTestCase $ \producer -> do
+      void $ perform @Text (at now) producer "a"
+
+    jobs `shouldMatchList` ["a", "HALT"]
+
+  it "can push Jobs to run in a given amount of seconds" $ do
+    jobs <- workerTestCase $ \producer -> do
+      void $ perform @Text (in_ 0) producer "a"
+
+    jobs `shouldMatchList` ["a", "HALT"]
 
   it "correctly handles fetch timeouts" $ do
     -- Pause longer than the fetch timeout


### PR DESCRIPTION
When we moved to handling `at`-vs-`in_` to an `Either` representation, the JSON
parser for reading back the `at`-value as a resolved `UTCTime` was incorrectly
implemented to construct with `Right` instead of `Left`.

This meant expecting a `NominimalDiffTime` instead, which fails.

```
[ERROR]: Invalid Job: Error in $.at: parsing NominalDiffTime failed, expected
Number, but encountered String
```

Jobs not enqueued with `at` (or `in_`) worked fine, which is how our tests
missed it.