### PR TITLE
Export lower-level Batch internals

### DIFF
--- a/library/Faktory/Ent/Batch.hs
+++ b/library/Faktory/Ent/Batch.hs
@@ -36,6 +36,11 @@ module Faktory.Ent.Batch
   , runBatch
   , Batch
   , batchPerform
+
+  -- * Low-level
+  , CustomBatchId(..)
+  , newBatch
+  , commitBatch
   ) where
 
 import Faktory.Prelude

--- a/library/Faktory/Ent/Batch.hs
+++ b/library/Faktory/Ent/Batch.hs
@@ -25,19 +25,18 @@
 -- Jobs to the Batch. PRs welcome.
 --
 module Faktory.Ent.Batch
-    (
-    -- * Options
-      BatchOptions
-    , description
-    , complete
-    , success
+  (
+  -- * Options
+    BatchOptions
+  , description
+  , complete
+  , success
 
-    -- * Running
-    , runBatch
-    , Batch
-    , batchPerform
-    )
-where
+  -- * Running
+  , runBatch
+  , Batch
+  , batchPerform
+  ) where
 
 import Faktory.Prelude
 


### PR DESCRIPTION
An overall wrapper (runBatch) is safest for the simple case. However, in other
contexts (ConduitT) we need to be able to call new/commit distinctly, which this
export will support.