### PR TITLE
Pass entire Job value to Worker loops

### DIFF
--- a/README.lhs
+++ b/README.lhs
@@ -79,9 +79,10 @@ newtype MyJob = MyJob
 ### Worker
 
 ```haskell
-workerMain = runWorkerEnv $ \job ->
+workerMain = runWorkerEnv $ \job -> do
   -- Process your Job here
-  putStrLn $ myJobMessage job
+  putStrLn $ jobJid job
+  putStrLn $ myJobMessage $ jobArg job
 
   -- If any exception is thrown, the job will be marked as Failed in Faktory
   -- and retried. Note: you will not otherwise hear about any such exceptions,

--- a/examples/consumer/Main.hs
+++ b/examples/consumer/Main.hs
@@ -16,7 +16,7 @@ main :: IO ()
 main = do
   putStrLn "Starting consumer loop"
   runWorkerEnv $ \job -> do
-    let message = jobMessage job
+    let message = jobMessage $ jobArg job
 
     if message == "BOOM"
       then throwString "Producer exception: BOOM"

--- a/tests/Faktory/Test.hs
+++ b/tests/Faktory/Test.hs
@@ -33,7 +33,8 @@ workerTestCaseWith editSettings run = do
   workerSettings <- editSettings <$> envWorkerSettings
 
   processedJobs <- newMVar []
-  a <- async $ runWorker settings workerSettings $ \job -> do
+  a <- async $ runWorker settings workerSettings $ \faktoryJob -> do
+    let job = jobArg faktoryJob
     modifyMVar_ processedJobs $ pure . (job :)
     when (job == "BOOM") $ throw $ userError "BOOM"
     when (job == "HALT") $ throw WorkerHalt


### PR DESCRIPTION
There are at least two concrete use-cases for knowing Job details within the
worker loop:

1. `BATCH` callback Jobs contain `options.custom._bid`, which can be used to ask
   Faktory if the batch succeeded or not. This is the only way to report
   success/failure to external monitoring from such Jobs (e.g. to Dead Man's
   Snitch).

2. `TRACK SET` can be used to update tracking details from within a tracked
   Job's processing (e.g. "30% done" or "145/500 Teachers updated"). To do so,
   the worker handling the Job needs the `jid`.

These uses, and who knows what others, mean we must supply the full Job type to
worker functions. Use-cases that don't need this will have to add a `jobArg`
call somewhere (as seen in many places in this diff).