### PR TITLE
Add BatchStatus module

### DIFF
--- a/faktory.cabal
+++ b/faktory.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.18
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 76c9c3936ed963ad73db63ab0896b13ea2dd4e0554222ccdfd7850e0a29ac352
+-- hash: 6f4a3ffef9141ff96c50ea7470ff7bde2223347fad180d1d1cb3922a879ae2a6
 
 name:           faktory
 version:        1.0.3.1
@@ -59,6 +59,7 @@ library
       Faktory.Client
       Faktory.Connection
       Faktory.Ent.Batch
+      Faktory.Ent.Batch.Status
       Faktory.Ent.Tracking
       Faktory.Job
       Faktory.Job.Custom
@@ -246,6 +247,7 @@ test-suite hspec
     , base >=4.13 && <5
     , faktory
     , hspec
+    , mtl
     , time
   if impl(ghc >= 8.10)
     ghc-options: -Wno-missing-safe-haskell-mode -Wno-prepositive-qualified-module

--- a/library/Faktory/Ent/Batch.hs
+++ b/library/Faktory/Ent/Batch.hs
@@ -38,6 +38,7 @@ module Faktory.Ent.Batch
   , batchPerform
 
   -- * Low-level
+  , BatchId(..)
   , CustomBatchId(..)
   , newBatch
   , commitBatch
@@ -62,7 +63,7 @@ newtype Batch a = Batch (ReaderT BatchId IO a)
   deriving newtype (Functor, Applicative, Monad, MonadIO, MonadReader BatchId)
 
 newtype BatchId = BatchId Text
-  deriving newtype ToJSON
+  deriving newtype (FromJSON, ToJSON)
 
 data BatchOptions arg = BatchOptions
   { boDescription :: Maybe (Last Text)

--- a/library/Faktory/Ent/Batch/Status.hs
+++ b/library/Faktory/Ent/Batch/Status.hs
@@ -1,0 +1,48 @@
+module Faktory.Ent.Batch.Status
+  ( jobBatchId
+  , BatchStatus(..)
+  , batchStatus
+  ) where
+
+import Faktory.Prelude
+
+import Control.Error.Util (hush)
+import Data.Aeson
+import Data.ByteString.Lazy as BSL
+import Data.Text.Encoding (encodeUtf8)
+import Data.Time (UTCTime)
+import Faktory.Client
+import Faktory.Ent.Batch
+import Faktory.Job (Job, jobOptions)
+import Faktory.Job.Custom
+import Faktory.JobOptions (JobOptions(..))
+import Faktory.Producer
+import GHC.Generics
+
+data BatchStatus = BatchStatus
+  { bid :: BatchId
+  , total :: Int
+  , pending :: Int
+  , failed :: Int
+  , created_at :: UTCTime
+  , description :: Text
+  }
+  deriving stock Generic
+  deriving anyclass FromJSON
+
+newtype ReadCustomBatchId = ReadCustomBatchId
+  { _bid :: BatchId
+  }
+  deriving stock Generic
+  deriving anyclass FromJSON
+
+jobBatchId :: Job arg -> Maybe BatchId
+jobBatchId job = do
+  custom <- joCustom $ jobOptions job
+  _bid <$> hush (fromCustom custom)
+
+batchStatus :: Producer -> BatchId -> IO (Either String (Maybe BatchStatus))
+batchStatus producer (BatchId bid) = commandJSON
+  (producerClient producer)
+  "BATCH STATUS"
+  [BSL.fromStrict $ encodeUtf8 bid]

--- a/library/Faktory/Job.hs
+++ b/library/Faktory/Job.hs
@@ -14,6 +14,7 @@ module Faktory.Job
   , newJob
   , jobJid
   , jobArg
+  , jobOptions
   ) where
 
 import Faktory.Prelude

--- a/library/Faktory/Job/Custom.hs
+++ b/library/Faktory/Job/Custom.hs
@@ -6,6 +6,7 @@
 module Faktory.Job.Custom
     ( Custom
     , toCustom
+    , fromCustom
     ) where
 
 import Faktory.Prelude
@@ -19,6 +20,12 @@ newtype Custom = Custom Value
 
 toCustom :: ToJSON a => a -> Custom
 toCustom = Custom . toJSON
+
+-- | Read a 'Custom' value to a type using 'FromJSON'
+fromCustom :: FromJSON a => Custom -> Either String a
+fromCustom (Custom v) = case fromJSON v of
+  Error e -> Left e
+  Success a -> Right a
 
 instance Semigroup Custom where
   (Custom (Object a)) <> (Custom (Object b)) =

--- a/package.yaml
+++ b/package.yaml
@@ -136,6 +136,7 @@ tests:
       - aeson
       - async
       - hspec
+      - mtl
       - time
 
   readme:


### PR DESCRIPTION
To support this required some re-plumbing:

- Export `jobOptions`, and `BatchId` internals
- Extend `Custom` for easier reading
- Extract lower-level test-helpers