### PR TITLE
Deprecate trackPerform

### DIFF
--- a/library/Faktory/Ent/Tracking.hs
+++ b/library/Faktory/Ent/Tracking.hs
@@ -4,6 +4,7 @@
 --
 module Faktory.Ent.Tracking
   ( CustomTrack(..)
+  , tracked
   , trackPerform
 
   , JobDetails(..)
@@ -36,6 +37,9 @@ newtype CustomTrack = CustomTrack
   deriving stock Generic
   deriving anyclass ToJSON
 
+tracked :: JobOptions
+tracked = custom (CustomTrack 1)
+
 -- | 'perform', but adding @{ custom: { track: 1 } }@
 --
 -- Equivalent to:
@@ -47,6 +51,7 @@ newtype CustomTrack = CustomTrack
 trackPerform
   :: (HasCallStack, ToJSON arg) => JobOptions -> Producer -> arg -> IO JobId
 trackPerform options = perform (options <> custom (CustomTrack 1))
+{-# DEPRECATED trackPerform "Use ‘perform (options <> tracked)’ instead" #-}
 
 data JobDetails = JobDetails
   { jdJid :: JobId

--- a/tests/Faktory/Ent/TrackingSpec.hs
+++ b/tests/Faktory/Ent/TrackingSpec.hs
@@ -11,13 +11,13 @@ import Faktory.Ent.Tracking
 
 spec :: Spec
 spec = do
-  describe "trackPerform" $ do
-    it "enqueues with TRACK so we can get details" $ do
+  describe "tracked" $ do
+    it "adds custom option so we can use TRACK GET later" $ do
       var <- newMVar []
       void $ workerTestCase $ \producer -> do
-        a <- trackPerform @Text mempty producer "a"
+        a <- perform @Text tracked producer "a"
         modifyMVar_ var $ pure . (<> [a])
-        b <- trackPerform @Text mempty producer "BOOM"
+        b <- perform @Text tracked producer "BOOM"
         modifyMVar_ var $ pure . (<> [b])
 
       enqueuedJobIds <- readMVar var
@@ -40,7 +40,7 @@ spec = do
     it "updates Job Details" $ do
       var <- newMVar []
       void $ workerTestCase $ \producer -> do
-        a <- trackPerform @Text mempty producer "a"
+        a <- perform @Text tracked producer "a"
         modifyMVar_ var $ pure . (<> [a])
 
       enqueuedJobIds <- readMVar var


### PR DESCRIPTION
Defining this function was unnecessary. Providing a `JobOptions` helper fits much
better with the overall library and is not too much extra characters:

```
trackPerform options producer job
==
perform (options <> tracked) producer job
```

Exporting `trackPerform` actually fit poorly in our own usage, nudging us the
wrong way and ending up with tracked Jobs _not_ going through our centralized
`enqueue` function (which does things like defaulting options).

Had we exposed `tracked` to begin with, it would've been obvious to use our
centralized `enqueue` but just append the `tracked` option as needed.

At the first commit, the tests are still using it, in order to display the
deprecation for review:

```
    .../tests/Faktory/Ent/TrackingSpec.hs:43:14: error: [-Wdeprecations, -Werror=deprecations]
        In the use of ‘trackPerform’ (imported from Faktory.Ent.Tracking):
        Deprecated: "Use ‘perform (options <> tracked)’ instead"
       |
    43 |         a <- trackPerform @Text mempty producer "a"
       |              ^^^^^^^^^^^^
```