### PR TITLE
Add jobRetriesRemaining

### DIFF
--- a/faktory.cabal
+++ b/faktory.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.18
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: a3c30d707e3f30cd0d1247e8ebf59d018160a9b448b3608e07607b126f30a7a4
+-- hash: 00ab48e4ab12fbd541c603178f5fa91fa1ab32169c371e1f12f1d9f441a6e076
 
 name:           faktory
 version:        1.1.0.0
@@ -63,6 +63,7 @@ library
       Faktory.Ent.Tracking
       Faktory.Job
       Faktory.Job.Custom
+      Faktory.JobFailure
       Faktory.JobOptions
       Faktory.JobState
       Faktory.Prelude
@@ -211,6 +212,7 @@ test-suite hspec
       Faktory.Ent.BatchSpec
       Faktory.Ent.TrackingSpec
       Faktory.JobOptionsSpec
+      Faktory.JobSpec
       Faktory.Test
       FaktorySpec
       Paths_faktory
@@ -243,6 +245,7 @@ test-suite hspec
   ghc-options: -Weverything -Wno-missing-exported-signatures -Wno-missed-specialisations -Wno-all-missed-specialisations -Wno-unsafe -Wno-safe -Wno-missing-local-signatures -Wno-monomorphism-restriction -Wno-missing-import-lists -rtsopts
   build-depends:
       aeson
+    , aeson-qq
     , async
     , base >=4.13 && <5
     , faktory

--- a/library/Faktory/Job.hs
+++ b/library/Faktory/Job.hs
@@ -15,17 +15,20 @@ module Faktory.Job
   , jobJid
   , jobArg
   , jobOptions
+  , jobRetriesRemaining
   ) where
 
 import Faktory.Prelude
 
 import Data.Aeson
 import Data.List.NonEmpty (NonEmpty)
+import Data.Semigroup (Last(..))
 import qualified Data.List.NonEmpty as NE
 import Data.Time (UTCTime)
 import Faktory.Client (Client(..))
 import Faktory.Connection (ConnectionInfo(..))
 import Faktory.JobOptions
+import Faktory.JobFailure
 import Faktory.Producer (Producer(..), pushJob)
 import Faktory.Settings (Namespace, Settings(..))
 import GHC.Stack
@@ -39,6 +42,7 @@ data Job arg = Job
   -- ^ Faktory needs to serialize args as a list, but we like a single-argument
   -- interface so that's what we expose. See @'jobArg'@.
   , jobOptions :: JobOptions
+  , jobFailure :: Maybe JobFailure
   }
 
 -- | Perform a Job with the given options
@@ -85,10 +89,17 @@ newJob arg = do
     , jobAt = Nothing
     , jobArgs = pure arg
     , jobOptions = jobtype "Default"
+    , jobFailure = Nothing
     }
 
 jobArg :: Job arg -> arg
 jobArg Job {..} = NE.head jobArgs
+
+jobRetriesRemaining :: Job arg -> Int
+jobRetriesRemaining job = max 0 $ enqueuedRetry - occurredRetries
+  where
+    enqueuedRetry = maybe faktoryDefaultRetry getLast $ joRetry $ jobOptions job
+    occurredRetries = maybe 0 ((+1) . jfRetryCount) $ jobFailure job
 
 instance ToJSON args => ToJSON (Job args) where
   toJSON = object . toPairs
@@ -113,5 +124,13 @@ instance FromJSON args => FromJSON (Job args) where
     <*> o .:? "at"
     <*> o .: "args"
     <*> parseJSON (Object o)
+    <*> o .:? "failure"
 
 type JobId = String
+
+-- | https://github.com/contribsys/faktory/wiki/Job-Errors#the-process
+--
+-- > By default Faktory will retry a job 25 times
+--
+faktoryDefaultRetry :: Int
+faktoryDefaultRetry = 25

--- a/library/Faktory/Job.hs
+++ b/library/Faktory/Job.hs
@@ -97,9 +97,9 @@ jobArg Job {..} = NE.head jobArgs
 
 jobRetriesRemaining :: Job arg -> Int
 jobRetriesRemaining job = max 0 $ enqueuedRetry - attemptCount
-  where
-    enqueuedRetry = maybe faktoryDefaultRetry getLast $ joRetry $ jobOptions job
-    attemptCount = maybe 0 ((+1) . jfRetryCount) $ jobFailure job
+ where
+  enqueuedRetry = maybe faktoryDefaultRetry getLast $ joRetry $ jobOptions job
+  attemptCount = maybe 0 ((+ 1) . jfRetryCount) $ jobFailure job
 
 instance ToJSON args => ToJSON (Job args) where
   toJSON = object . toPairs

--- a/library/Faktory/Job.hs
+++ b/library/Faktory/Job.hs
@@ -22,13 +22,13 @@ import Faktory.Prelude
 
 import Data.Aeson
 import Data.List.NonEmpty (NonEmpty)
-import Data.Semigroup (Last(..))
 import qualified Data.List.NonEmpty as NE
+import Data.Semigroup (Last(..))
 import Data.Time (UTCTime)
 import Faktory.Client (Client(..))
 import Faktory.Connection (ConnectionInfo(..))
-import Faktory.JobOptions
 import Faktory.JobFailure
+import Faktory.JobOptions
 import Faktory.Producer (Producer(..), pushJob)
 import Faktory.Settings (Namespace, Settings(..))
 import GHC.Stack

--- a/library/Faktory/Job.hs
+++ b/library/Faktory/Job.hs
@@ -96,10 +96,10 @@ jobArg :: Job arg -> arg
 jobArg Job {..} = NE.head jobArgs
 
 jobRetriesRemaining :: Job arg -> Int
-jobRetriesRemaining job = max 0 $ enqueuedRetry - occurredRetries
+jobRetriesRemaining job = max 0 $ enqueuedRetry - attemptCount
   where
     enqueuedRetry = maybe faktoryDefaultRetry getLast $ joRetry $ jobOptions job
-    occurredRetries = maybe 0 ((+1) . jfRetryCount) $ jobFailure job
+    attemptCount = maybe 0 ((+1) . jfRetryCount) $ jobFailure job
 
 instance ToJSON args => ToJSON (Job args) where
   toJSON = object . toPairs

--- a/library/Faktory/JobFailure.hs
+++ b/library/Faktory/JobFailure.hs
@@ -1,0 +1,28 @@
+module Faktory.JobFailure
+  ( JobFailure(..)
+  ) where
+
+import Faktory.Prelude
+
+import Data.Aeson
+import Data.Time (UTCTime)
+
+data JobFailure = JobFailure
+  { jfRetryCount :: Int
+  , jfFailedAt :: UTCTime
+  , jfNextAt :: Maybe UTCTime
+  , jfErrorMessage :: Maybe Text
+  , jfErrorType :: Maybe Text
+  , jfBacktrace :: Maybe [Text]
+  }
+
+-- brittany-disable-next-binding
+
+instance FromJSON JobFailure where
+  parseJSON = withObject "Failure" $ \o -> JobFailure
+    <$> o .: "retry_count"
+    <*> o .: "failed_at"
+    <*> o .:? "next_at"
+    <*> o .:? "error_message"
+    <*> o .:? "error_type"
+    <*> o .:? "backtrace"

--- a/package.yaml
+++ b/package.yaml
@@ -134,6 +134,7 @@ tests:
     dependencies:
       - faktory
       - aeson
+      - aeson-qq
       - async
       - hspec
       - mtl

--- a/tests/Faktory/JobSpec.hs
+++ b/tests/Faktory/JobSpec.hs
@@ -1,0 +1,132 @@
+{-# LANGUAGE QuasiQuotes #-}
+
+module Faktory.JobSpec
+  ( spec
+  ) where
+
+import Faktory.Prelude
+
+import Data.Time (getCurrentTime)
+import Faktory.Job
+import Data.Aeson
+import Data.Aeson.QQ
+import Test.Hspec
+
+spec :: Spec
+spec = do
+  -- https://github.com/contribsys/faktory/issues/374#issuecomment-902075572
+  describe "jobRetriesRemaining" $ do
+    it "handles first consumed" $ do
+      job <- decodeJob [aesonQQ|
+        { "jid": "abc"
+        , "args": [""]
+        , "retry": 2
+        }
+      |]
+
+      jobRetriesRemaining job `shouldBe` 2
+
+    it "handles a first retry" $ do
+      now <- getCurrentTime
+      job <- decodeJob [aesonQQ|
+        { "jid": "abc"
+        , "args": [""]
+        , "retry": 2
+        , "failure":
+          { "retry_count": 0
+          , "failed_at": #{now}
+          }
+        }
+      |]
+
+      jobRetriesRemaining job `shouldBe` 1
+
+    it "handles a final retry" $ do
+      now <- getCurrentTime
+      job <- decodeJob [aesonQQ|
+        { "jid": "abc"
+        , "args": [""]
+        , "retry": 2
+        , "failure":
+          { "retry_count": 1
+          , "failed_at": #{now}
+          }
+        }
+      |]
+
+      jobRetriesRemaining job `shouldBe` 0
+
+    it "uses Faktory's default" $ do
+      job <- decodeJob [aesonQQ|
+        { "jid": "abc"
+        , "args": [""]
+        }
+      |]
+
+      jobRetriesRemaining job `shouldBe` 25
+
+    it "handles retry -1" $ do
+      now <- getCurrentTime
+      job1 <- decodeJob [aesonQQ|
+        { "jid": "abc"
+        , "args": [""]
+        , "retry": -1
+        }
+      |]
+      job2 <- decodeJob [aesonQQ|
+        { "jid": "abc"
+        , "args": [""]
+        , "retry": -1
+        , "failure":
+          { "retry_count": 1
+          , "failed_at": #{now}
+          }
+        }
+      |]
+
+      jobRetriesRemaining job1 `shouldBe` 0
+      jobRetriesRemaining job2 `shouldBe` 0
+
+    it "handles retry 0" $ do
+      now <- getCurrentTime
+      job1 <- decodeJob [aesonQQ|
+        { "jid": "abc"
+        , "args": [""]
+        , "retry": 0
+        }
+      |]
+      job2 <- decodeJob [aesonQQ|
+        { "jid": "abc"
+        , "args": [""]
+        , "retry": 0
+        , "failure":
+          { "retry_count": 1
+          , "failed_at": #{now}
+          }
+        }
+      |]
+
+      jobRetriesRemaining job1 `shouldBe` 0
+      jobRetriesRemaining job2 `shouldBe` 0
+
+    it "handles nonsense" $ do
+      now <- getCurrentTime
+      job <- decodeJob [aesonQQ|
+        { "jid": "abc"
+        , "args": [""]
+        , "retry": 20
+        , "failure":
+          { "retry_count": 1000
+          , "failed_at": #{now}
+          }
+        }
+      |]
+
+      jobRetriesRemaining job `shouldBe` 0
+
+decodeJob :: Value -> IO (Job Text)
+decodeJob v = case fromJSON v of
+  Error err -> do
+    expectationFailure $ "Job JSON did not parse: " <> err
+    error "unreachable" -- I hate that hspec makes ^ IO () and not IO a
+  Success job -> pure job

--- a/tests/Faktory/JobSpec.hs
+++ b/tests/Faktory/JobSpec.hs
@@ -6,10 +6,10 @@ module Faktory.JobSpec
 
 import Faktory.Prelude
 
-import Data.Time (getCurrentTime)
-import Faktory.Job
 import Data.Aeson
 import Data.Aeson.QQ
+import Data.Time (getCurrentTime)
+import Faktory.Job
 import Test.Hspec
 
 spec :: Spec


### PR DESCRIPTION
Ultimately, we want this to reduce alerting noise by only notifying to Bugsnag
of Job exceptions once `jobRetriesRemaining == 0`.

I chose to parse the whole `JobFailure` value since we are a library and others
may find those bits useful. Also, it was a trivial parse with mostly nullable
fields.

I wrote a temporary spec that enqueued a Job with retries and verified lots of
actual behavior as they were processed, but I am not committing it because it
takes forever to run, since it has to actually wait for Faktory's retry delays.

See https://github.com/contribsys/faktory/issues/374 for more details.