### PR TITLE
Handle reserve_for

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## [*Unreleased*](https://github.com/frontrowed/faktory_worker_haskell/compare/v1.1.1.0...main)
 
-None
+- Add `reserveFor` and `jobReserveForMicroseconds` for setting `ACK` window for
+  individual jobs.
+- Timeout jobs that have exceeded their `reserve_for` setting. Jobs without an
+  explicit `reserve_for` will default to Faktory's 1800 second timeout.
 
 ## [v1.1.1.0](https://github.com/frontrowed/faktory_worker_haskell/compare/v1.1.0.1...v1.1.1.0)
 

--- a/library/Faktory/Job.hs
+++ b/library/Faktory/Job.hs
@@ -105,13 +105,9 @@ jobRetriesRemaining job = max 0 $ enqueuedRetry - attemptCount
 
 jobReserveForMicroseconds :: Job arg -> Int
 jobReserveForMicroseconds =
-  (* 1000)
-    . maybe faktoryTimeoutDefault (fromIntegral . getLast)
+  maybe faktoryDefaultReserveFor (secondToMicrosecond . fromIntegral . getLast)
     . joReserveFor
     . jobOptions
-
-faktoryTimeoutDefault :: Int
-faktoryTimeoutDefault = 1800
 
 instance ToJSON args => ToJSON (Job args) where
   toJSON = object . toPairs
@@ -147,3 +143,9 @@ type JobId = String
 --
 faktoryDefaultRetry :: Int
 faktoryDefaultRetry = 25
+
+faktoryDefaultReserveFor :: Int
+faktoryDefaultReserveFor = secondToMicrosecond 1800
+
+secondToMicrosecond :: Int -> Int
+secondToMicrosecond n = n * (10 ^ (6 :: Int))

--- a/library/Faktory/Job.hs
+++ b/library/Faktory/Job.hs
@@ -17,7 +17,7 @@ module Faktory.Job
   , jobArg
   , jobOptions
   , jobRetriesRemaining
-  , jobReserveFor
+  , jobReserveForMicroseconds
   ) where
 
 import Faktory.Prelude
@@ -34,7 +34,6 @@ import Faktory.JobOptions
 import Faktory.Producer (Producer(..), pushJob)
 import Faktory.Settings (Namespace, Settings(..))
 import GHC.Stack
-import Numeric.Natural (Natural)
 import System.Random
 
 data Job arg = Job
@@ -104,15 +103,22 @@ jobRetriesRemaining job = max 0 $ enqueuedRetry - attemptCount
   enqueuedRetry = maybe faktoryDefaultRetry getLast $ joRetry $ jobOptions job
   attemptCount = maybe 0 ((+ 1) . jfRetryCount) $ jobFailure job
 
-jobReserveFor :: Job arg -> Maybe Natural
-jobReserveFor = fmap getLast . joReserveFor . jobOptions
+jobReserveForMicroseconds :: Job arg -> Int
+jobReserveForMicroseconds =
+  (* 1000)
+    . maybe faktoryTimeoutDefault (fromIntegral . getLast)
+    . joReserveFor
+    . jobOptions
+
+faktoryTimeoutDefault :: Int
+faktoryTimeoutDefault = 1800
 
 instance ToJSON args => ToJSON (Job args) where
   toJSON = object . toPairs
   toEncoding = pairs . mconcat . toPairs
 
 toPairs :: (KeyValue a, ToJSON arg) => Job arg -> [a]
-toPairs job@Job {..} =
+toPairs Job {..} =
   [ "jid" .= jobJid
   , "at" .= jobAt
   , "args" .= jobArgs
@@ -120,7 +126,7 @@ toPairs job@Job {..} =
   , "retry" .= joRetry jobOptions
   , "queue" .= joQueue jobOptions
   , "custom" .= joCustom jobOptions
-  , "reserve_for" .= jobReserveFor job
+  , "reserve_for" .= joReserveFor jobOptions
   ]
 
 -- brittany-disable-next-binding

--- a/library/Faktory/Worker.hs
+++ b/library/Faktory/Worker.hs
@@ -18,7 +18,7 @@ import Data.Aeson
 import Data.Aeson.Casing
 import qualified Data.Text as T
 import Faktory.Client
-import Faktory.Job (Job, JobId, jobArg, jobJid, jobReserveFor)
+import Faktory.Job (Job, JobId, jobArg, jobJid, jobReserveForMicroseconds)
 import Faktory.Settings
 import GHC.Generics
 import GHC.Stack
@@ -91,7 +91,7 @@ processorLoop client settings workerSettings f = do
   let
     namespace = connectionInfoNamespace $ settingsConnection settings
     processAndAck job = do
-      mResult <- timeout (getJobTTL job) $ do
+      mResult <- timeout (jobReserveForMicroseconds job) $ do
         f job
         ackJob client job
       case mResult of
@@ -110,12 +110,6 @@ processorLoop client settings workerSettings f = do
                   , Handler $ \(ex :: SomeException) ->
                     failJob client job $ T.pack $ show ex
                   ]
-
-getJobTTL :: Job arg -> Int
-getJobTTL = (* 1000) . maybe faktoryTimeoutDefault fromIntegral . jobReserveFor
-
-faktoryTimeoutDefault :: Int
-faktoryTimeoutDefault = 1800
 
 -- | <https://github.com/contribsys/faktory/wiki/Worker-Lifecycle#heartbeat>
 heartBeat :: Client -> WorkerId -> IO ()

--- a/library/Faktory/Worker.hs
+++ b/library/Faktory/Worker.hs
@@ -91,12 +91,10 @@ processorLoop client settings workerSettings f = do
   let
     namespace = connectionInfoNamespace $ settingsConnection settings
     processAndAck job = do
-      mResult <- timeout (jobReserveForMicroseconds job) $ do
-        f job
-        ackJob client job
+      mResult <- timeout (jobReserveForMicroseconds job) $ f job
       case mResult of
         Nothing -> settingsLogError settings "Job reservation period expired."
-        Just () -> pure ()
+        Just () -> ackJob client job
 
   emJob <- fetchJob client $ namespaceQueue namespace $ settingsQueue
     workerSettings

--- a/library/Faktory/Worker.hs
+++ b/library/Faktory/Worker.hs
@@ -96,7 +96,7 @@ processorLoop client settings workerSettings f = do
         ackJob client job
       case mResult of
         Nothing -> settingsLogError settings "Job reservation period expired."
-        Just{} -> pure ()
+        Just () -> pure ()
 
   emJob <- fetchJob client $ namespaceQueue namespace $ settingsQueue
     workerSettings

--- a/tests/Faktory/JobSpec.hs
+++ b/tests/Faktory/JobSpec.hs
@@ -132,7 +132,7 @@ spec = do
         }
       |]
 
-      jobReserveForMicroseconds job `shouldBe` 3600000
+      jobReserveForMicroseconds job `shouldBe` 3600000000
 
 decodeJob :: Value -> IO (Job Text)
 decodeJob v = case fromJSON v of

--- a/tests/Faktory/JobSpec.hs
+++ b/tests/Faktory/JobSpec.hs
@@ -124,6 +124,16 @@ spec = do
 
       jobRetriesRemaining job `shouldBe` 0
 
+    it "handles reserve_for" $ do
+      job <- decodeJob [aesonQQ|
+        { "jid": "abc"
+        , "args": [""]
+        , "reserve_for": 3600
+        }
+      |]
+
+      jobReserveFor job `shouldBe` Just 3600
+
 decodeJob :: Value -> IO (Job Text)
 decodeJob v = case fromJSON v of
   Error err -> do

--- a/tests/Faktory/JobSpec.hs
+++ b/tests/Faktory/JobSpec.hs
@@ -132,7 +132,7 @@ spec = do
         }
       |]
 
-      jobReserveFor job `shouldBe` Just 3600
+      jobReserveForMicroseconds job `shouldBe` 3600000
 
 decodeJob :: Value -> IO (Job Text)
 decodeJob v = case fromJSON v of

--- a/tests/Faktory/Test.hs
+++ b/tests/Faktory/Test.hs
@@ -58,7 +58,7 @@ startWorker editSettings = do
 
     runWorker settings workerSettings $ \faktoryJob -> do
       let job = jobArg faktoryJob
-      when (job == "WAIT") $ threadDelay 3000
+      when (job == "WAIT") $ threadDelay 3000000
       modifyMVar_ processedJobs $ pure . (job :)
       when (job == "BOOM") $ throw $ userError "BOOM"
       when (job == "HALT") $ throw WorkerHalt

--- a/tests/Faktory/Test.hs
+++ b/tests/Faktory/Test.hs
@@ -18,6 +18,7 @@ import Faktory.Job as X
 import Faktory.Producer as X
 import Test.Hspec as X
 
+import Control.Concurrent (threadDelay)
 import Control.Concurrent.Async
 import Control.Concurrent.MVar
 import Faktory.Settings
@@ -57,6 +58,7 @@ startWorker editSettings = do
 
     runWorker settings workerSettings $ \faktoryJob -> do
       let job = jobArg faktoryJob
+      when (job == "WAIT") $ threadDelay 3000
       modifyMVar_ processedJobs $ pure . (job :)
       when (job == "BOOM") $ throw $ userError "BOOM"
       when (job == "HALT") $ throw WorkerHalt

--- a/tests/FaktorySpec.hs
+++ b/tests/FaktorySpec.hs
@@ -51,3 +51,15 @@ spec = describe "Faktory" $ do
       threadDelay $ 2 * 1000000 + 250000
 
     jobs `shouldMatchList` ["HALT"]
+
+  it "does not process jobs when reserve_for timeout expires" $ do
+    jobs <- workerTestCase $ \producer -> do
+      void $ perform @Text (reserveFor 1) producer "WAIT"
+
+    jobs `shouldMatchList` ["HALT"]
+
+  it "processes jobs within reserve_for window" $ do
+    jobs <- workerTestCase $ \producer -> do
+      void $ perform @Text (reserveFor 4) producer "WAIT"
+
+    jobs `shouldMatchList` ["WAIT", "HALT"]


### PR DESCRIPTION
## Issue

#71 

## Description 

### Add reserve_for to job options

Faktory allows a job to prescribe how long it should wait to recieve an
`ACK` before considering the consumer dead. This is passed via
`reserve_for`, the number of seconds to wait.

### Prevent zombie consumers by respecting reserve_for

`reserve_for` is an optional configuration for jobs. If it is not
provided the default is 1800 seconds. This value describes the window in
which a consumer may process and job and send back an `ACK`. If an `ACK`
is not sent in this period then Faktory will hand the job to another
consumer.

Not respecting this TTL can result in __zombie__ jobs. A worker that
exceeds the `reserve_for` will continue functioning while Faktory may
have passed the job to another worker. This can cause duplicate effort,
performance issues, and logical bugs.

This change simply places a `timeout` around the job processing time.
This ensures the job is appropriately timed. The current implementation
is silent, no information is logged, the job is just terminated. That is
likely not desirable.