### PR TITLE
Allow configuration of default retry and queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
   individual jobs.
 - Timeout jobs that have exceeded their `reserve_for` setting. Jobs without an
   explicit `reserve_for` will default to Faktory's 1800 second timeout.
+- Allow configuration of default job options via `settingsDefaultJobOptions`.
 
 ## [v1.1.1.0](https://github.com/frontrowed/faktory_worker_haskell/compare/v1.1.0.1...v1.1.1.0)
 

--- a/faktory.cabal
+++ b/faktory.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.18
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 164b18ff06b7a72987aaf4f1a7f4d870101c275ab001fbc7be906f69671682df
+-- hash: 48d5a03acb6447032ad3071a8873ce4f630a35844848f83852c21a2b46b688c7
 
 name:           faktory
 version:        1.1.1.0
@@ -70,6 +70,7 @@ library
       Faktory.Producer
       Faktory.Protocol
       Faktory.Settings
+      Faktory.Settings.Queue
       Faktory.Worker
   other-modules:
       Paths_faktory

--- a/library/Faktory/Job.hs
+++ b/library/Faktory/Job.hs
@@ -72,13 +72,17 @@ applyOptions namespace options job = do
 
 -- | Construct a 'Job' and apply options and Producer settings
 buildJob :: JobOptions -> Producer -> arg -> IO (Job arg)
-buildJob options producer arg = applyOptions namespace options =<< newJob arg
+buildJob options producer arg = applyOptions namespace (applyDefaults options)
+  =<< newJob arg
  where
   namespace =
     connectionInfoNamespace
       $ settingsConnection
       $ clientSettings
       $ producerClient producer
+  applyDefaults =
+    mappend $ settingsDefaultJobOptions $ clientSettings $ producerClient
+      producer
 
 -- | Construct a 'Job' with default 'JobOptions'
 newJob :: arg -> IO (Job arg)

--- a/library/Faktory/JobOptions.hs
+++ b/library/Faktory/JobOptions.hs
@@ -25,8 +25,8 @@ import Data.Semigroup (Last(..))
 import Data.Semigroup.Generic
 import Data.Time
 import Faktory.Job.Custom
-import Faktory.Settings (Namespace, Queue)
-import qualified Faktory.Settings as Settings
+import Faktory.Settings.Queue (Namespace, Queue)
+import qualified Faktory.Settings.Queue as Settings
 import GHC.Generics
 import Numeric.Natural (Natural)
 
@@ -52,7 +52,7 @@ data JobOptions = JobOptions
   , joCustom :: Maybe Custom
   , joReserveFor :: Maybe (Last Natural)
   }
-  deriving stock Generic
+  deriving stock (Eq, Show, Generic)
   deriving (Semigroup, Monoid) via GenericSemigroupMonoid JobOptions
 
 -- brittany-disable-next-binding

--- a/library/Faktory/Settings.hs
+++ b/library/Faktory/Settings.hs
@@ -20,10 +20,9 @@ module Faktory.Settings
 import Faktory.Prelude
 
 import Data.Aeson
-import Data.ByteString.Lazy (ByteString, fromStrict)
-import Data.String
-import Data.Text.Encoding (encodeUtf8)
 import Faktory.Connection
+import Faktory.JobOptions (JobOptions)
+import Faktory.Settings.Queue
 import System.Environment (lookupEnv)
 import System.IO (hPutStrLn, stderr)
 import System.Random
@@ -32,6 +31,7 @@ data Settings = Settings
   { settingsConnection :: ConnectionInfo
   , settingsLogDebug :: String -> IO ()
   , settingsLogError :: String -> IO ()
+  , settingsDefaultJobOptions :: JobOptions
   }
 
 defaultSettings :: Settings
@@ -39,6 +39,7 @@ defaultSettings = Settings
   { settingsConnection = defaultConnectionInfo
   , settingsLogDebug = \_msg -> pure ()
   , settingsLogError = hPutStrLn stderr . ("[ERROR]: " <>)
+  , settingsDefaultJobOptions = mempty
   }
 
 -- | Defaults, but read @'Connection'@ from the environment
@@ -71,19 +72,6 @@ envWorkerSettings = do
     { settingsQueue = maybe defaultQueue (Queue . pack) mQueue
     , settingsId = WorkerId <$> mWorkerId
     }
-
-newtype Queue = Queue Text
-  deriving stock (Eq, Show)
-  deriving newtype (IsString, FromJSON, ToJSON)
-
-namespaceQueue :: Namespace -> Queue -> Queue
-namespaceQueue (Namespace n) (Queue q) = Queue $ mappend n q
-
-queueArg :: Queue -> ByteString
-queueArg (Queue q) = fromStrict $ encodeUtf8 q
-
-defaultQueue :: Queue
-defaultQueue = "default"
 
 newtype WorkerId = WorkerId String
   deriving newtype (FromJSON, ToJSON)

--- a/library/Faktory/Settings/Queue.hs
+++ b/library/Faktory/Settings/Queue.hs
@@ -1,0 +1,28 @@
+module Faktory.Settings.Queue
+  ( Queue(..)
+  , namespaceQueue
+  , queueArg
+  , defaultQueue
+  , Namespace(..)
+  ) where
+
+import Faktory.Prelude
+
+import Data.Aeson
+import Data.ByteString.Lazy (ByteString, fromStrict)
+import Data.String
+import Data.Text.Encoding (encodeUtf8)
+import Faktory.Connection
+
+newtype Queue = Queue Text
+  deriving stock (Eq, Show)
+  deriving newtype (IsString, FromJSON, ToJSON)
+
+namespaceQueue :: Namespace -> Queue -> Queue
+namespaceQueue (Namespace n) (Queue q) = Queue $ mappend n q
+
+queueArg :: Queue -> ByteString
+queueArg (Queue q) = fromStrict $ encodeUtf8 q
+
+defaultQueue :: Queue
+defaultQueue = "default"


### PR DESCRIPTION
Faktory has defaults for `queue: default` and `retry: 25`. This means
that `queue` and `retry` are not required settings, however these
defaults may not be desired, but the optionality makes it painful to
enforce across a project. This enhancement allows these defaults values
to be configured within `Settings` data. This allows `queue` and `retry`
to remain optional, but fall back to a project defined default.