### PR TITLE
Add HasJobType to correctly report `jobType` to Faktory

### DIFF
--- a/README.lhs
+++ b/README.lhs
@@ -74,6 +74,9 @@ newtype MyJob = MyJob
   }
   deriving stock Generic
   deriving anyclass (ToJSON, FromJSON)
+
+instance HasJobType MyJob where
+  jobTypeName _ = "MyJob"
 ```
 
 ### Worker

--- a/examples/producer/Main.hs
+++ b/examples/producer/Main.hs
@@ -4,7 +4,7 @@ import Prelude
 
 import Control.Exception.Safe
 import Data.Aeson
-import Faktory.Job (perform)
+import Faktory.Job (HasJobType(..), perform)
 import Faktory.Producer
 import GHC.Generics
 import System.Environment (getArgs)
@@ -13,6 +13,9 @@ import System.Environment (getArgs)
 newtype Job = Job { jobMessage :: String }
   deriving stock Generic
   deriving anyclass ToJSON
+
+instance HasJobType Job where
+  jobTypeName _ = "Job"
 
 main :: IO ()
 main = bracket newProducerEnv closeProducer $ \producer -> do

--- a/faktory.cabal
+++ b/faktory.cabal
@@ -66,6 +66,7 @@ library
       Faktory.JobFailure
       Faktory.JobOptions
       Faktory.JobState
+      Faktory.JobType
       Faktory.Prelude
       Faktory.Producer
       Faktory.Protocol

--- a/library/Faktory/Ent/Batch.hs
+++ b/library/Faktory/Ent/Batch.hs
@@ -99,7 +99,11 @@ newtype CustomBatchId = CustomBatchId
   deriving anyclass ToJSON
 
 batchPerform
-  :: (HasCallStack, ToJSON arg) => JobOptions -> Producer -> arg -> Batch JobId
+  :: (HasCallStack, HasJobType arg, ToJSON arg)
+  => JobOptions
+  -> Producer
+  -> arg
+  -> Batch JobId
 batchPerform options producer arg = do
   bid <- ask
   Batch $ lift $ perform (options <> custom (CustomBatchId bid)) producer arg

--- a/library/Faktory/Ent/Tracking.hs
+++ b/library/Faktory/Ent/Tracking.hs
@@ -25,7 +25,7 @@ import qualified Data.ByteString.Lazy.Char8 as BSL8
 import Data.Maybe (fromMaybe)
 import Data.Time (UTCTime)
 import Faktory.Client (commandJSON, commandOK)
-import Faktory.Job (JobId, JobOptions, custom, perform)
+import Faktory.Job (HasJobType, JobId, JobOptions, custom, perform)
 import Faktory.JobState (JobState(..))
 import Faktory.Producer
 import GHC.Generics (Generic)
@@ -49,7 +49,11 @@ tracked = custom (CustomTrack 1)
 -- @
 --
 trackPerform
-  :: (HasCallStack, ToJSON arg) => JobOptions -> Producer -> arg -> IO JobId
+  :: (HasCallStack, HasJobType arg, ToJSON arg)
+  => JobOptions
+  -> Producer
+  -> arg
+  -> IO JobId
 trackPerform options = perform (options <> custom (CustomTrack 1))
 {-# DEPRECATED trackPerform "Use ‘perform (options <> tracked)’ instead" #-}
 

--- a/library/Faktory/JobOptions.hs
+++ b/library/Faktory/JobOptions.hs
@@ -45,7 +45,7 @@ import Numeric.Natural (Natural)
 -- already-present retries to @x@.
 --
 data JobOptions = JobOptions
-  { joJobtype :: Maybe (Last String)
+  { joJobtype :: Maybe (Last Text)
   , joRetry :: Maybe (Last Int)
   , joQueue :: Maybe (Last Queue)
   , joSchedule :: Maybe (Last (Either UTCTime NominalDiffTime))
@@ -90,7 +90,7 @@ once = retry (-1)
 queue :: Queue -> JobOptions
 queue q = mempty { joQueue = Just $ Last q }
 
-jobtype :: String -> JobOptions
+jobtype :: Text -> JobOptions
 jobtype jt = mempty { joJobtype = Just $ Last jt }
 
 at :: UTCTime -> JobOptions

--- a/library/Faktory/JobType.hs
+++ b/library/Faktory/JobType.hs
@@ -1,0 +1,8 @@
+module Faktory.JobType
+  ( HasJobType(..)
+  ) where
+
+import Faktory.Prelude
+
+class HasJobType a where
+  jobTypeName :: a -> Text

--- a/tests/Faktory/Ent/BatchSpec.hs
+++ b/tests/Faktory/Ent/BatchSpec.hs
@@ -14,77 +14,77 @@ spec = do
   describe "runBatch" $ do
     it "runs a success job if all in-batch jobs succeed" $ do
       jobs <- workerTestCase $ \producer -> do
-        c <- buildJob @Text mempty producer "c"
+        c <- buildJob mempty producer $ J "c"
         void $ runBatch (success c) producer $ do
-          void $ batchPerform @Text mempty producer "a"
-          void $ batchPerform @Text mempty producer "b"
+          void $ batchPerform mempty producer $ J "a"
+          void $ batchPerform mempty producer $ J "b"
         -- Give a little time for Faktory to fire the callback
         liftIO $ threadDelay 500000
 
-      jobs `shouldMatchList` ["a", "b", "c", "HALT"]
+      jobs `shouldMatchList` ["a", "b", "c", Halt]
 
     it "does not run a success job if all jobs don't succeed" $ do
       jobs <- workerTestCase $ \producer -> do
-        c <- buildJob @Text mempty producer "c"
+        c <- buildJob mempty producer $ J "c"
         void $ runBatch (success c) producer $ do
-          void $ batchPerform @Text mempty producer "BOOM"
-          void $ batchPerform @Text mempty producer "b"
+          void $ batchPerform mempty producer Boom
+          void $ batchPerform mempty producer $ J "b"
         liftIO $ threadDelay 500000
 
-      jobs `shouldMatchList` ["BOOM", "b", "HALT"]
+      jobs `shouldMatchList` [Boom, "b", Halt]
 
     it "runs a job on complete" $ do
       jobs <- workerTestCase $ \producer -> do
-        c <- buildJob @Text mempty producer "c"
+        c <- buildJob mempty producer $ J "c"
         void $ runBatch (complete c) producer $ do
-          void $ batchPerform @Text mempty producer "a"
-          void $ batchPerform @Text mempty producer "b"
+          void $ batchPerform mempty producer $ J "a"
+          void $ batchPerform mempty producer $ J "b"
         liftIO $ threadDelay 500000
 
-      jobs `shouldMatchList` ["a", "b", "c", "HALT"]
+      jobs `shouldMatchList` ["a", "b", "c", Halt]
 
     it "runs a job on complete, even if in-batch jobs fail" $ do
       jobs <- workerTestCase $ \producer -> do
-        c <- buildJob @Text mempty producer "c"
+        c <- buildJob mempty producer $ J "c"
         void $ runBatch (complete c) producer $ do
-          void $ batchPerform @Text mempty producer "BOOM"
-          void $ batchPerform @Text mempty producer "b"
+          void $ batchPerform mempty producer Boom
+          void $ batchPerform mempty producer $ J "b"
         liftIO $ threadDelay 500000
 
-      jobs `shouldMatchList` ["BOOM", "b", "c", "HALT"]
+      jobs `shouldMatchList` [Boom, "b", "c", Halt]
 
     it "combines duplicate options in last-wins fashion" $ do
       jobs <- workerTestCase $ \producer -> do
-        c <- buildJob @Text mempty producer "c"
-        d <- buildJob @Text mempty producer "d"
+        c <- buildJob mempty producer $ J "c"
+        d <- buildJob mempty producer $ J "d"
         let options = description "foo" <> success c <> success d
         void $ runBatch options producer $ do
-          void $ batchPerform @Text mempty producer "a"
-          void $ batchPerform @Text mempty producer "b"
+          void $ batchPerform mempty producer $ J "a"
+          void $ batchPerform mempty producer $ J "b"
         liftIO $ threadDelay 500000
 
-      jobs `shouldMatchList` ["a", "b", "d", "HALT"]
+      jobs `shouldMatchList` ["a", "b", "d", Halt]
 
     it "runs success and complete if all Jobs were successful" $ do
       jobs <- workerTestCase $ \producer -> do
-        c <- buildJob @Text mempty producer "c"
-        d <- buildJob @Text mempty producer "d"
+        c <- buildJob mempty producer $ J "c"
+        d <- buildJob mempty producer $ J "d"
         let options = description "foo" <> complete c <> success d
         void $ runBatch options producer $ do
-          void $ batchPerform @Text mempty producer "a"
-          void $ batchPerform @Text mempty producer "b"
+          void $ batchPerform mempty producer $ J "a"
+          void $ batchPerform mempty producer $ J "b"
         liftIO $ threadDelay 500000
 
-      jobs `shouldMatchList` ["a", "b", "c", "d", "HALT"]
+      jobs `shouldMatchList` ["a", "b", "c", "d", Halt]
 
     it "supports BATCH STATUS" $ do
       batchId <- withWorker id $ withProducer $ \producer -> do
-        c <- buildJob @Text mempty producer "c"
-        d <- buildJob @Text mempty producer "d"
+        c <- buildJob mempty producer $ J "c"
+        d <- buildJob mempty producer $ J "d"
         let options = description "foo" <> complete c <> success d
         batchId <- runBatch options producer $ do
-          void $ batchPerform @Text mempty producer "a"
-          void $ batchPerform @Text mempty producer "b"
+          void $ batchPerform mempty producer $ J "a"
+          void $ batchPerform mempty producer $ J "b"
           ask
         batchId <$ liftIO (threadDelay 500000)
 

--- a/tests/Faktory/Ent/TrackingSpec.hs
+++ b/tests/Faktory/Ent/TrackingSpec.hs
@@ -15,9 +15,9 @@ spec = do
     it "adds custom option so we can use TRACK GET later" $ do
       var <- newMVar []
       void $ workerTestCase $ \producer -> do
-        a <- perform @Text tracked producer "a"
+        a <- perform tracked producer $ J "a"
         modifyMVar_ var $ pure . (<> [a])
-        b <- perform @Text tracked producer "BOOM"
+        b <- perform tracked producer Boom
         modifyMVar_ var $ pure . (<> [b])
 
       enqueuedJobIds <- readMVar var
@@ -40,7 +40,7 @@ spec = do
     it "updates Job Details" $ do
       var <- newMVar []
       void $ workerTestCase $ \producer -> do
-        a <- perform @Text tracked producer "a"
+        a <- perform tracked producer $ J "a"
         modifyMVar_ var $ pure . (<> [a])
 
       enqueuedJobIds <- readMVar var

--- a/tests/FaktorySpec.hs
+++ b/tests/FaktorySpec.hs
@@ -12,30 +12,30 @@ spec :: Spec
 spec = describe "Faktory" $ do
   it "can push and process jobs" $ do
     jobs <- workerTestCase $ \producer -> do
-      void $ perform @Text mempty producer "a"
-      void $ perform @Text mempty producer "b"
+      void $ perform mempty producer $ J "a"
+      void $ perform mempty producer $ J "b"
 
-    jobs `shouldMatchList` ["a", "b", "HALT"]
+    jobs `shouldMatchList` ["a", "b", Halt]
 
   it "can push jobs with optional attributes" $ do
     jobs <- workerTestCase $ \producer -> do
-      void $ perform @Text once producer "a"
-      void $ perform @Text (retry 0) producer "b"
+      void $ perform once producer $ J "a"
+      void $ perform (retry 0) producer $ J "b"
 
-    jobs `shouldMatchList` ["a", "b", "HALT"]
+    jobs `shouldMatchList` ["a", "b", Halt]
 
   it "can push Jobs to run at a given time" $ do
     now <- getCurrentTime
     jobs <- workerTestCase $ \producer -> do
-      void $ perform @Text (at now) producer "a"
+      void $ perform (at now) producer $ J "a"
 
-    jobs `shouldMatchList` ["a", "HALT"]
+    jobs `shouldMatchList` ["a", Halt]
 
   it "can push Jobs to run in a given amount of seconds" $ do
     jobs <- workerTestCase $ \producer -> do
-      void $ perform @Text (in_ 0) producer "a"
+      void $ perform (in_ 0) producer $ J "a"
 
-    jobs `shouldMatchList` ["a", "HALT"]
+    jobs `shouldMatchList` ["a", Halt]
 
   it "correctly handles fetch timeouts" $ do
     -- Pause longer than the fetch timeout
@@ -50,16 +50,16 @@ spec = describe "Faktory" $ do
     jobs <- workerTestCaseWith editSettings $ \_ -> do
       threadDelay $ 2 * 1000000 + 250000
 
-    jobs `shouldMatchList` ["HALT"]
+    jobs `shouldMatchList` [Halt]
 
   it "does not process jobs when reserve_for timeout expires" $ do
     jobs <- workerTestCase $ \producer -> do
-      void $ perform @Text (reserveFor 1) producer "WAIT"
+      void $ perform (reserveFor 1) producer Wait
 
-    jobs `shouldMatchList` ["HALT"]
+    jobs `shouldMatchList` [Halt]
 
   it "processes jobs within reserve_for window" $ do
     jobs <- workerTestCase $ \producer -> do
-      void $ perform @Text (reserveFor 4) producer "WAIT"
+      void $ perform (reserveFor 4) producer Wait
 
-    jobs `shouldMatchList` ["WAIT", "HALT"]
+    jobs `shouldMatchList` [Wait, Halt]


### PR DESCRIPTION
`jobType` within Faktory is not heavily utilized by this library,
however it is useful from a reporting perspective. This enhancement adds
a `HasJobType` class that ensures any `ToJSON` passed to `perform` also
implements a `jobTypeName` to be reported in Faktory. This is an easy
constraint to satisfy, but it does cause a breaking change.