### PR TITLE
Support aeson 2.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,5 +34,15 @@ jobs:
       with:
         stack-yaml: ${{ matrix.stack-yaml }}
         weeder: false
+        hlint: false
       env:
         FAKTORY_URL: tcp://localhost:7419
+
+  hlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: rwe/actions-hlint-setup@v1
+      - uses: rwe/actions-hlint-run@v2
+        with:
+          fail-on: warning

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
-## [*Unreleased*](https://github.com/frontrowed/faktory_worker_haskell/compare/v1.1.2.0...main)
+## [*Unreleased*](https://github.com/frontrowed/faktory_worker_haskell/compare/v1.1.2.1...main)
 
 None
+
+## [v1.1.2.1](https://github.com/frontrowed/faktory_worker_haskell/compare/v1.1.2.0...v1.1.2.1)
+
+- Support `aeson` 2.x
 
 ## [v1.1.2.0](https://github.com/frontrowed/faktory_worker_haskell/compare/v1.1.1.0...v1.1.2.0)
 

--- a/faktory.cabal
+++ b/faktory.cabal
@@ -4,10 +4,10 @@ cabal-version: 1.18
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 48d5a03acb6447032ad3071a8873ce4f630a35844848f83852c21a2b46b688c7
+-- hash: 1c90eb3cb55f665ff829e01574d08ece733fe5fcac86925dd2f31e323577661b
 
 name:           faktory
-version:        1.1.1.0
+version:        1.1.2.1
 synopsis:       Faktory Worker for Haskell
 description:    Haskell client and worker process for the Faktory background job server.
                 .

--- a/library/Faktory/Job/Custom.hs
+++ b/library/Faktory/Job/Custom.hs
@@ -12,7 +12,6 @@ module Faktory.Job.Custom
 import Faktory.Prelude
 
 import Data.Aeson
-import qualified Data.HashMap.Strict as HashMap
 
 newtype Custom = Custom Value
   deriving stock (Eq, Show)
@@ -28,6 +27,5 @@ fromCustom (Custom v) = case fromJSON v of
   Success a -> Right a
 
 instance Semigroup Custom where
-  (Custom (Object a)) <> (Custom (Object b)) =
-    Custom $ Object $ HashMap.union b a
+  (Custom (Object a)) <> (Custom (Object b)) = Custom $ Object $ b <> a
   _ <> b = b

--- a/package.yaml
+++ b/package.yaml
@@ -1,6 +1,6 @@
 ---
 name: faktory
-version: 1.1.2.0
+version: 1.1.2.1
 category: Network
 author: Freckle Engineering
 maintainer: engineering@freckle.com

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,3 +1,6 @@
-resolver: lts-17.1
+resolver: nightly-2021-11-28
 ghc-options:
   "$locals": -fwrite-ide-info
+
+extra-deps:
+  - aeson-2.0.2.0@sha256:5720fffb7289366029f2b7940e9f8b22a1b4c282f0cef4710685b1d14d76bdc7,6327

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -3,10 +3,17 @@
 # For more information, please see the documentation at:
 #   https://docs.haskellstack.org/en/stable/lock_files
 
-packages: []
+packages:
+- completed:
+    hackage: aeson-2.0.2.0@sha256:5720fffb7289366029f2b7940e9f8b22a1b4c282f0cef4710685b1d14d76bdc7,6327
+    pantry-tree:
+      size: 37910
+      sha256: 6de8e70acd5ed455ac33d7496e8dbf994067f1f845dd420e7256623b2a8dee8b
+  original:
+    hackage: aeson-2.0.2.0@sha256:5720fffb7289366029f2b7940e9f8b22a1b4c282f0cef4710685b1d14d76bdc7,6327
 snapshots:
 - completed:
-    size: 563098
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/17/1.yaml
-    sha256: 395775c03e66a4286f134d50346b0b6f1432131cf542886252984b4cfa5fef69
-  original: lts-17.1
+    size: 598989
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/nightly/2021/11/28.yaml
+    sha256: a7be81bf4d78de268e05b805b34a6bf320dd7f19892139824196ef48c7eb4990
+  original: nightly-2021-11-28


### PR DESCRIPTION
closes: https://github.com/freckle/faktory_worker_haskell/issues/82

The latest version of `aeson` replaces its object `HashMap`
representation with an internal facade. Since the only action faktory
needs is `union`, this can be replaced with a generic monoidal action.
This allows faktory to support 2.x and lower.