### PR TITLE
Fix jobBatchId parser to work for all job types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
-## [*Unreleased*](https://github.com/frontrowed/faktory_worker_haskell/compare/v1.1.2.3...main)
+## [_Unreleased_](https://github.com/frontrowed/faktory_worker_haskell/compare/v1.1.2.4...main)
+
+## [v1.1.2.4](https://github.com/frontrowed/faktory_worker_haskell/compare/v1.1.2.3...v1.1.2.4)
+
+- Fix `jobBatchId` to work for all job types. Faktory seems to use both `bid` and `_bid`
+  in a jobs custom object when enqueing jobs. This allows the parser to use both
 
 ## [v1.1.2.3](https://github.com/frontrowed/faktory_worker_haskell/compare/v1.1.2.2...v1.1.2.3)
 

--- a/faktory.cabal
+++ b/faktory.cabal
@@ -4,10 +4,10 @@ cabal-version: 1.18
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 40381b06d8fbd259879f14aa5d043243b301d5be044f06a279d20e2b9d6374d4
+-- hash: 90987000132ede41855e5c19e984c2d6e88e9efa27154587d6a965ae91efd56a
 
 name:           faktory
-version:        1.1.2.3
+version:        1.1.2.4
 synopsis:       Faktory Worker for Haskell
 description:    Haskell client and worker process for the Faktory background job server.
                 .

--- a/library/Faktory/Ent/Batch.hs
+++ b/library/Faktory/Ent/Batch.hs
@@ -63,7 +63,7 @@ newtype Batch a = Batch (ReaderT BatchId IO a)
   deriving newtype (Functor, Applicative, Monad, MonadIO, MonadReader BatchId)
 
 newtype BatchId = BatchId Text
-  deriving stock (Show,Eq)
+  deriving stock (Show, Eq)
   deriving newtype (FromJSON, ToJSON)
 
 data BatchOptions arg = BatchOptions

--- a/library/Faktory/Ent/Batch.hs
+++ b/library/Faktory/Ent/Batch.hs
@@ -63,6 +63,7 @@ newtype Batch a = Batch (ReaderT BatchId IO a)
   deriving newtype (Functor, Applicative, Monad, MonadIO, MonadReader BatchId)
 
 newtype BatchId = BatchId Text
+  deriving stock (Show,Eq)
   deriving newtype (FromJSON, ToJSON)
 
 data BatchOptions arg = BatchOptions

--- a/library/Faktory/Ent/Batch/Status.hs
+++ b/library/Faktory/Ent/Batch/Status.hs
@@ -6,6 +6,7 @@ module Faktory.Ent.Batch.Status
 
 import Faktory.Prelude
 
+import Control.Applicative ((<|>))
 import Control.Error.Util (hush)
 import Data.Aeson
 import Data.ByteString.Lazy as BSL
@@ -18,7 +19,6 @@ import Faktory.Job.Custom
 import Faktory.JobOptions (JobOptions(..))
 import Faktory.Producer
 import GHC.Generics
-import Control.Applicative ((<|>))
 
 data BatchStatus = BatchStatus
   { bid :: BatchId
@@ -37,7 +37,7 @@ newtype ReadCustomBatchId = ReadCustomBatchId
   deriving stock (Show,Eq,Generic)
 
 instance FromJSON ReadCustomBatchId where
-  -- Faktory seems to use the key '_bid' when enqueuing callback jobs and 'bid' for normal jobs... 
+  -- Faktory seems to use the key '_bid' when enqueuing callback jobs and 'bid' for normal jobs...
   parseJSON v = withParser "_bid" v <|> withParser "bid" v
    where
     withParser s =

--- a/package.yaml
+++ b/package.yaml
@@ -1,6 +1,6 @@
 ---
 name: faktory
-version: 1.1.2.3
+version: 1.1.2.4
 category: Network
 author: Freckle Engineering
 maintainer: engineering@freckle.com

--- a/tests/Faktory/Ent/BatchSpec.hs
+++ b/tests/Faktory/Ent/BatchSpec.hs
@@ -7,8 +7,8 @@ import Faktory.Test
 import Control.Concurrent (threadDelay)
 import Control.Monad.Reader
 import Faktory.Ent.Batch
-import qualified Faktory.Ent.Batch.Status as BatchStatus
 import Faktory.Ent.Batch.Status (jobBatchId)
+import qualified Faktory.Ent.Batch.Status as BatchStatus
 
 spec :: Spec
 spec = do

--- a/tests/Faktory/Ent/BatchSpec.hs
+++ b/tests/Faktory/Ent/BatchSpec.hs
@@ -4,12 +4,12 @@ module Faktory.Ent.BatchSpec
 
 import Faktory.Test
 
+import Control.Arrow ((&&&))
 import Control.Concurrent (threadDelay)
 import Control.Monad.Reader
 import Faktory.Ent.Batch
 import Faktory.Ent.Batch.Status (jobBatchId)
 import qualified Faktory.Ent.Batch.Status as BatchStatus
-import Control.Arrow ((&&&))
 
 spec :: Spec
 spec = do

--- a/tests/Faktory/Ent/BatchSpec.hs
+++ b/tests/Faktory/Ent/BatchSpec.hs
@@ -9,6 +9,7 @@ import Control.Monad.Reader
 import Faktory.Ent.Batch
 import Faktory.Ent.Batch.Status (jobBatchId)
 import qualified Faktory.Ent.Batch.Status as BatchStatus
+import Control.Arrow ((&&&))
 
 spec :: Spec
 spec = do
@@ -24,12 +25,12 @@ spec = do
           ask
         batchId <$ liftIO (threadDelay 500000)
 
-      fmap jobBatchId jobs
-        `shouldMatchList` [ Nothing
-                          , Just batchId
-                          , Just batchId
-                          , Just batchId
-                          , Just batchId
+      fmap (jobArg &&& jobBatchId) jobs
+        `shouldMatchList` [ ("HALT", Nothing)
+                          , ("a", Just batchId)
+                          , ("b", Just batchId)
+                          , ("c", Just batchId)
+                          , ("d", Just batchId)
                           ]
 
   describe "runBatch" $ do

--- a/tests/Faktory/Test.hs
+++ b/tests/Faktory/Test.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE TupleSections #-}
+
 module Faktory.Test
   ( module X
   , workerTestCase

--- a/tests/FaktorySpec.hs
+++ b/tests/FaktorySpec.hs
@@ -15,27 +15,27 @@ spec = describe "Faktory" $ do
       void $ perform @Text mempty producer "a"
       void $ perform @Text mempty producer "b"
 
-    jobs `shouldMatchList` ["a", "b", "HALT"]
+    fmap jobArg jobs `shouldMatchList` ["a", "b", "HALT"]
 
   it "can push jobs with optional attributes" $ do
     jobs <- workerTestCase $ \producer -> do
       void $ perform @Text once producer "a"
       void $ perform @Text (retry 0) producer "b"
 
-    jobs `shouldMatchList` ["a", "b", "HALT"]
+    fmap jobArg jobs `shouldMatchList` ["a", "b", "HALT"]
 
   it "can push Jobs to run at a given time" $ do
     now <- getCurrentTime
     jobs <- workerTestCase $ \producer -> do
       void $ perform @Text (at now) producer "a"
 
-    jobs `shouldMatchList` ["a", "HALT"]
+    fmap jobArg jobs `shouldMatchList` ["a", "HALT"]
 
   it "can push Jobs to run in a given amount of seconds" $ do
     jobs <- workerTestCase $ \producer -> do
       void $ perform @Text (in_ 0) producer "a"
 
-    jobs `shouldMatchList` ["a", "HALT"]
+    fmap jobArg jobs `shouldMatchList` ["a", "HALT"]
 
   it "correctly handles fetch timeouts" $ do
     -- Pause longer than the fetch timeout
@@ -50,16 +50,16 @@ spec = describe "Faktory" $ do
     jobs <- workerTestCaseWith editSettings $ \_ -> do
       threadDelay $ 2 * 1000000 + 250000
 
-    jobs `shouldMatchList` ["HALT"]
+    fmap jobArg jobs `shouldMatchList` ["HALT"]
 
   it "does not process jobs when reserve_for timeout expires" $ do
     jobs <- workerTestCase $ \producer -> do
       void $ perform @Text (reserveFor 1) producer "WAIT"
 
-    jobs `shouldMatchList` ["HALT"]
+    fmap jobArg jobs `shouldMatchList` ["HALT"]
 
   it "processes jobs within reserve_for window" $ do
     jobs <- workerTestCase $ \producer -> do
       void $ perform @Text (reserveFor 4) producer "WAIT"
 
-    jobs `shouldMatchList` ["WAIT", "HALT"]
+    fmap jobArg jobs `shouldMatchList` ["WAIT", "HALT"]


### PR DESCRIPTION
When working on https://renaissancelearning.atlassian.net/wiki/spaces/EN/pages/42568319218/Long-running+operations+artifacts a bug was discovered with the `jobBatchId` function. It does not parse the custom object correctly for the batch id in instances where the key is `bid` and not `_bid`.

Faktory seems to use both `_bid` and `bid` as keys for the batch id in the custom object for jobs. Normal jobs get the `bid` key and callback jobs seem to get the `_bid` formulation.

This updates the parser able to parse both styles.