### PR TITLE
Fail Jobs that don't decode as expected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
-## [_Unreleased_](https://github.com/frontrowed/faktory_worker_haskell/compare/v1.1.2.6...main)
+## [_Unreleased_](https://github.com/frontrowed/faktory_worker_haskell/compare/v1.1.2.7...main)
+
+## [v1.1.2.7](https://github.com/frontrowed/faktory_worker_haskell/compare/v1.1.2.6...v1.1.2.7)
+
+- Fix handling decoding errors of the Job payload. Previously, it would log an
+  error and neither `ACK` nor `FAIL` the Job. Now it `FAIL`s the Job.
 
 ## [v1.1.2.6](https://github.com/frontrowed/faktory_worker_haskell/compare/v1.1.2.5...v1.1.2.6)
 

--- a/faktory.cabal
+++ b/faktory.cabal
@@ -4,10 +4,10 @@ cabal-version: 1.18
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 3745aedbf1b91d2c710a7d56cf5802cd63e7e0279f80be134fc79f850ed6cfe6
+-- hash: 4e8530827601475a141f2b1524153409a869122bcd0dafe12b70368e0aefcf07
 
 name:           faktory
-version:        1.1.2.6
+version:        1.1.2.7
 synopsis:       Faktory Worker for Haskell
 description:    Haskell client and worker process for the Faktory background job server.
                 .

--- a/library/Faktory/Job.hs
+++ b/library/Faktory/Job.hs
@@ -48,7 +48,7 @@ data Job arg = Job
   , jobOptions :: JobOptions
   , jobFailure :: Maybe JobFailure
   }
-  deriving stock (Show, Functor)
+  deriving stock (Show, Functor, Foldable, Traversable)
 
 -- | Perform a Job with the given options
 --

--- a/library/Faktory/Job.hs
+++ b/library/Faktory/Job.hs
@@ -48,6 +48,7 @@ data Job arg = Job
   , jobOptions :: JobOptions
   , jobFailure :: Maybe JobFailure
   }
+  deriving stock (Show, Functor)
 
 -- | Perform a Job with the given options
 --

--- a/library/Faktory/JobFailure.hs
+++ b/library/Faktory/JobFailure.hs
@@ -15,6 +15,7 @@ data JobFailure = JobFailure
   , jfErrorType :: Maybe Text
   , jfBacktrace :: Maybe [Text]
   }
+  deriving stock (Show)
 
 -- brittany-disable-next-binding
 

--- a/library/Faktory/Settings.hs
+++ b/library/Faktory/Settings.hs
@@ -55,6 +55,7 @@ data WorkerSettings = WorkerSettings
   { settingsQueue :: Queue
   , settingsId :: Maybe WorkerId
   , settingsIdleDelay :: Int
+  , settingsOnFailed :: SomeException -> IO ()
   }
 
 defaultWorkerSettings :: WorkerSettings
@@ -63,6 +64,7 @@ defaultWorkerSettings =
     { settingsQueue = defaultQueue
     , settingsId = Nothing
     , settingsIdleDelay = 1
+    , settingsOnFailed = \_ -> pure ()
     }
 
 envWorkerSettings :: IO WorkerSettings

--- a/library/Faktory/Worker.hs
+++ b/library/Faktory/Worker.hs
@@ -107,7 +107,8 @@ processorLoop client settings workerSettings f = do
     Right (Just job) ->
       processAndAck job
         `catches` [ Handler $ \(ex :: WorkerHalt) -> throw ex
-                  , Handler $ \(ex :: SomeException) ->
+                  , Handler $ \(ex :: SomeException) -> do
+                      settingsOnFailed workerSettings ex
                       failJob client job $ T.pack $ show ex
                   ]
 

--- a/package.yaml
+++ b/package.yaml
@@ -1,6 +1,6 @@
 ---
 name: faktory
-version: 1.1.2.6
+version: 1.1.2.7
 category: Network
 author: Freckle Engineering
 maintainer: engineering@freckle.com

--- a/tests/Faktory/Ent/BatchSpec.hs
+++ b/tests/Faktory/Ent/BatchSpec.hs
@@ -15,7 +15,7 @@ spec :: Spec
 spec = do
   describe "jobBatchId" $ do
     it "parses the batchId out of batch jobs" $ do
-      (jobs, batchId) <- withWorker id $ withProducer $ \producer -> do
+      (jobs, _, batchId) <- withWorker id $ withProducer $ \producer -> do
         c <- buildJob @Text mempty producer "c"
         d <- buildJob @Text mempty producer "d"
         let options = description "foo" <> complete c <> success d
@@ -100,7 +100,7 @@ spec = do
       fmap jobArg jobs `shouldMatchList` ["a", "b", "c", "d", "HALT"]
 
     it "supports BATCH STATUS" $ do
-      (_, batchId) <- withWorker id $ withProducer $ \producer -> do
+      (_, _, batchId) <- withWorker id $ withProducer $ \producer -> do
         c <- buildJob @Text mempty producer "c"
         d <- buildJob @Text mempty producer "d"
         let options = description "foo" <> complete c <> success d

--- a/tests/Faktory/Test.hs
+++ b/tests/Faktory/Test.hs
@@ -34,10 +34,8 @@ workerTestCaseWith
   => (WorkerSettings -> WorkerSettings)
   -> (Producer -> IO ())
   -> IO [Job Text]
-workerTestCaseWith editSettings run = do
-  a <- startWorker editSettings
-  withProducer run
-  haltWorker a
+workerTestCaseWith editSettings =
+  fmap fst . withWorker editSettings . withProducer
 
 withProducer :: (Producer -> IO a) -> IO a
 withProducer f = bracket newProducerEnv closeProducer f

--- a/tests/FaktorySpec.hs
+++ b/tests/FaktorySpec.hs
@@ -69,3 +69,9 @@ spec = describe "Faktory" $ do
       void $ perform @Text mempty producer "BOOM"
 
     failed `shouldSatisfy` (== 1) . length
+
+  it "fails jobs that didn't parse" $ do
+    (_, failed, _) <- withWorker id $ withProducer $ \producer -> do
+      void $ perform @Int mempty producer 42
+
+    failed `shouldSatisfy` (== 1) . length

--- a/tests/FaktorySpec.hs
+++ b/tests/FaktorySpec.hs
@@ -63,3 +63,9 @@ spec = describe "Faktory" $ do
       void $ perform @Text (reserveFor 4) producer "WAIT"
 
     fmap jobArg jobs `shouldMatchList` ["WAIT", "HALT"]
+
+  it "fails jobs that raise exceptions" $ do
+    (_, failed, _) <- withWorker id $ withProducer $ \producer -> do
+      void $ perform @Text mempty producer "BOOM"
+
+    failed `shouldSatisfy` (== 1) . length


### PR DESCRIPTION
Originally, this decoding failure would enter the `Left` case and only
log the error. The Job would hang, neither `ACK`ed nor `FAIL`ed until
its reservation expired.

Now, as long as it is valid JSON, we reach the `Right`-`Just` branch and
attempt to decode it further there. This way, if it can't decode, that
exception occurs in the right place to `FAIL` the job, as desired.

Closes https://github.com/freckle/faktory_worker_haskell/issues/88.