### PR TITLE
Add Faktory.Pool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
-## [_Unreleased_](https://github.com/frontrowed/faktory_worker_haskell/compare/v1.1.2.7...main)
+## [_Unreleased_](https://github.com/frontrowed/faktory_worker_haskell/compare/v1.1.3.0...main)
+
+## [v1.1.3.0](https://github.com/frontrowed/faktory_worker_haskell/compare/v1.1.2.7...v1.1.3.0)
+
+- Add `Faktory.Pool`
+
+  This incurs the new dependencies, `unliftio`, `resource-pool`, and
+  `microlens`.
 
 ## [v1.1.2.7](https://github.com/frontrowed/faktory_worker_haskell/compare/v1.1.2.6...v1.1.2.7)
 

--- a/faktory.cabal
+++ b/faktory.cabal
@@ -7,7 +7,7 @@ cabal-version: 1.18
 -- hash: 690e0deaa46069fadbd59ee63f2da1a97d4fb5bcadabf75910d088636b34bbf9
 
 name:           faktory
-version:        1.1.2.7
+version:        1.1.3.0
 synopsis:       Faktory Worker for Haskell
 description:    Haskell client and worker process for the Faktory background job server.
                 .

--- a/faktory.cabal
+++ b/faktory.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.18
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 690e0deaa46069fadbd59ee63f2da1a97d4fb5bcadabf75910d088636b34bbf9
+-- hash: 89f1872b73104a5e3c9199c20692c3b0da3ba450a23bdfd7aad3d2bacc7bcb6c
 
 name:           faktory
 version:        1.1.3.0
@@ -56,6 +56,7 @@ source-repository head
 
 library
   exposed-modules:
+      Data.Pool.Compat
       Faktory.Client
       Faktory.Connection
       Faktory.Ent.Batch

--- a/faktory.cabal
+++ b/faktory.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.18
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 4e8530827601475a141f2b1524153409a869122bcd0dafe12b70368e0aefcf07
+-- hash: 690e0deaa46069fadbd59ee63f2da1a97d4fb5bcadabf75910d088636b34bbf9
 
 name:           faktory
 version:        1.1.2.7
@@ -66,6 +66,7 @@ library
       Faktory.JobFailure
       Faktory.JobOptions
       Faktory.JobState
+      Faktory.Pool
       Faktory.Prelude
       Faktory.Producer
       Faktory.Protocol
@@ -112,15 +113,18 @@ library
     , errors
     , megaparsec
     , memory
+    , microlens
     , mtl
     , network
     , random
+    , resource-pool
     , safe-exceptions
     , scanner
     , semigroups >=0.19.1
     , text
     , time
     , unix
+    , unliftio
     , unordered-containers
   default-language: Haskell2010
   if impl(ghc >= 8.10)

--- a/library/Data/Pool/Compat.hs
+++ b/library/Data/Pool/Compat.hs
@@ -1,0 +1,31 @@
+{-# LANGUAGE CPP #-}
+
+module Data.Pool.Compat
+  ( module Data.Pool
+  , createPool
+  ) where
+
+import Prelude
+
+import Data.Pool hiding (createPool)
+#if MIN_VERSION_resource_pool(0,3,0)
+#else
+import Control.Concurrent (getNumCapabilities)
+import qualified Data.Pool as Pool
+#endif
+
+createPool
+  :: IO a
+  -> (a -> IO ())
+  -> Double
+  -> Int
+  -> IO (Pool a)
+createPool create destroy timeout size = do
+#if MIN_VERSION_resource_pool(0,3,0)
+  newPool $ defaultPoolConfig create destroy timeout size
+#else
+  -- Re-implement instead of using the deprecated compatibility function, so
+  -- that we can get a consistent numStripes and size behavior.
+  numStripes <- getNumCapabilities
+  Pool.createPool create destroy numStripes (realToFrac timeout) size
+#endif

--- a/library/Faktory/Pool.hs
+++ b/library/Faktory/Pool.hs
@@ -24,8 +24,8 @@ import Faktory.Prelude
 import Control.Monad.IO.Class (MonadIO (..))
 import Control.Monad.Reader (MonadReader, asks)
 import Data.Aeson (ToJSON)
-import Data.Pool (Pool)
-import qualified Data.Pool as Pool
+import Data.Pool.Compat (Pool)
+import qualified Data.Pool.Compat as Pool
 import Faktory.Job hiding (buildJob, perform)
 import qualified Faktory.Job as Job
 import Faktory.Producer
@@ -59,14 +59,13 @@ newFaktoryPool
   -> PoolSettings
   -> m FaktoryPool
 newFaktoryPool settings PoolSettings {..} = do
-  liftIO
-    . fmap FaktoryPool
-    . Pool.newPool
-    $ Pool.defaultPoolConfig
-      (newProducer settings)
-      closeProducer
-      (fromIntegral settingsTimeout)
-      (fromIntegral settingsSize)
+  liftIO $
+    FaktoryPool
+      <$> Pool.createPool
+        (newProducer settings)
+        closeProducer
+        (fromIntegral settingsTimeout)
+        (fromIntegral settingsSize)
 
 -- | 'Faktory.Job.perform' but using a 'Producer' from the pool
 --

--- a/library/Faktory/Pool.hs
+++ b/library/Faktory/Pool.hs
@@ -1,0 +1,126 @@
+module Faktory.Pool
+  ( FaktoryPool
+  , HasFaktoryPool (..)
+
+    -- * Pool Construction
+  , Settings
+  , PoolSettings
+  , newFaktoryPool
+
+    -- * Pool use
+  , perform
+  , buildJob
+
+    -- * Direct access
+  , withProducer
+  , takeProducer
+
+    -- * Re-exports
+  , module Faktory.Job
+  ) where
+
+import Faktory.Prelude
+
+import Control.Monad.IO.Class (MonadIO (..))
+import Control.Monad.Reader (MonadReader, asks)
+import Data.Aeson (ToJSON)
+import Data.Pool (Pool)
+import qualified Data.Pool as Pool
+import Faktory.Job hiding (buildJob, perform)
+import qualified Faktory.Job as Job
+import Faktory.Producer
+import Faktory.Settings (PoolSettings (..), Settings)
+import GHC.Stack (HasCallStack)
+import Lens.Micro (Lens', (^.))
+import UnliftIO (MonadUnliftIO, withRunInIO)
+
+-- |
+--
+-- @since 1.1.3.0
+type FaktoryPool = Pool Producer
+
+-- |
+--
+-- @since 1.1.3.0
+class HasFaktoryPool env where
+  faktoryPoolL :: Lens' env FaktoryPool
+
+instance HasFaktoryPool FaktoryPool where
+  faktoryPoolL = id
+
+-- | Build a 'FaktoryPool' with the given settings
+--
+-- See 'Settings', 'envSettings', 'PoolSettings', and 'envPoolSettings'.
+--
+-- @since 1.1.3.0
+newFaktoryPool
+  :: MonadIO m
+  => Settings
+  -> PoolSettings
+  -> m FaktoryPool
+newFaktoryPool settings PoolSettings {..} = do
+  liftIO
+    . Pool.newPool
+    $ Pool.defaultPoolConfig
+      (newProducer settings)
+      closeProducer
+      (fromIntegral settingsTimeout)
+      (fromIntegral settingsSize)
+
+-- | 'Faktory.Job.perform' but using a 'Producer' from the pool
+--
+-- @since 1.1.3.0
+perform
+  :: ( MonadUnliftIO m
+     , MonadReader env m
+     , HasFaktoryPool env
+     , ToJSON arg
+     , HasCallStack
+     )
+  => JobOptions
+  -> arg
+  -> m JobId
+perform options arg = do
+  withProducer $ \producer -> do
+    liftIO $ Job.perform options producer arg
+
+-- | 'Faktory.Job.buildJob' but using a 'Producer' from the pool
+--
+-- @since 1.1.3.0
+buildJob
+  :: (MonadUnliftIO m, MonadReader env m, HasFaktoryPool env)
+  => JobOptions
+  -> arg
+  -> m (Job arg)
+buildJob options arg = do
+  withProducer $ \producer -> do
+    liftIO $ Job.buildJob options producer arg
+
+-- | Acquire a 'Producer', use it, and return it to the pool
+--
+-- @since 1.1.3.0
+withProducer
+  :: (MonadUnliftIO m, MonadReader env m, HasFaktoryPool env)
+  => (Producer -> m a)
+  -> m a
+withProducer f = do
+  p <- asks (^. faktoryPoolL)
+  withRunInIO $ \runInIO -> do
+    Pool.withResource p $ runInIO . f
+
+-- | Get a 'Producer' from the pool along with an action to return it
+--
+-- You should prefer 'withProducer' if at all possible. With this function you
+-- are responsible to ensure the return action is called (e.g. with 'finally').
+--
+-- This is only necessary if you are operating in a monad that doesn't have
+-- 'MonadUnliftIO' (like 'ConduitT'), so you need to take and return a
+-- 'Producer' separately (e.g. with 'bracketP').
+--
+-- @since 1.1.3.0
+takeProducer
+  :: (MonadIO m, MonadReader env m, HasFaktoryPool env) => m (Producer, m ())
+takeProducer = do
+  p <- asks (^. faktoryPoolL)
+  (producer, lp) <- liftIO $ Pool.takeResource p
+  pure (producer, liftIO $ Pool.putResource lp producer)

--- a/package.yaml
+++ b/package.yaml
@@ -1,6 +1,6 @@
 ---
 name: faktory
-version: 1.1.2.7
+version: 1.1.3.0
 category: Network
 author: Freckle Engineering
 maintainer: engineering@freckle.com

--- a/package.yaml
+++ b/package.yaml
@@ -104,15 +104,18 @@ library:
     - errors
     - megaparsec
     - memory
+    - microlens
     - mtl
     - network
     - random
+    - resource-pool
     - safe-exceptions
     - semigroups >= 0.19.1
     - scanner
     - text
     - time
     - unix
+    - unliftio
     - unordered-containers
 
 executables:


### PR DESCRIPTION
This implements connection pooling by adding `HasFaktoryPool` which can
be used to acquire a `Producer`, which is just a `Client`, which is just
a `Connection`.

I chose the name `FaktoryPool` (instead of `FaktoryProducerPool`) for
two reasons, one conceptual and one practical:

- Conceptual: I think the `Producer` wrapper over `Client` is
  unnecessary. It adds nothing and a `Producer` could just as easily be
  used for any communication with Faktory, to produce, consume, batch,
  track, etc. So I consider this a "pool for Faktory" and no
  specifically "for Faktory _producers_". (Same reason we call it
  `SqlPool` and not `SqlInserterPool` or `SqlQuerierPool`.)
- Practical: we have a `FaktoryProducerPool` in `freckle-app`, that this
  is a generalization and upstreaming of. Changing the name along the
  way makes the errors clearer and more easy to deal with when
  converting downstream applications.

I have branch migrating backend from freckle-app to this and it's quite nice. There
are a few differences from freckle-app in my implementation here that  led to that:

- Providing 1-for-1 pool versions of `perform` and `buildJob` make conversion simpler
- My version of `takeProducer` made the necessary-evil of using the pool in `ConduitT` much nicer