### PR TITLE
Support CI without Faktory credentials

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,17 +21,11 @@ jobs:
       - id: prep
         run: |
           if [[ -n "$FAKTORY_REGISTRY_USERNAME" && -n "$FAKTORY_REGISTRY_PASSWORD" ]]; then
-            echo "Credentials found, using non-free faktory and running all tests"
-            image=docker.contribsys.com/contribsys/faktory-ent:1.4.0
-            arguments=''
+            echo 'test-image=docker.contribsys.com/contribsys/faktory-ent:1.4.0'
           else
-            echo "Credentials not found, using free faktory and skipping Faktory.Ent tests"
-            image=contribsys/faktory:1.4.0
-            arguments='--test-arguments="--skip Faktory.Ent"'
-          fi
-
-          echo "test-image=$image" >>"$GITHUB_OUTPUT"
-          echo "test-arguments=$arguments" >>"$GITHUB_OUTPUT"
+            echo 'test-image=contribsys/faktory:1.4.0'
+            echo 'test-arguments=--test-arguments="--skip Faktory.Ent"'
+          fi >>"$GITHUB_OUTPUT"
         env:
           FAKTORY_REGISTRY_USERNAME: ${{ secrets.FAKTORY_REGISTRY_USERNAME }}
           FAKTORY_REGISTRY_PASSWORD: ${{ secrets.FAKTORY_REGISTRY_PASSWORD }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
           FAKTORY_REGISTRY_PASSWORD: ${{ secrets.FAKTORY_REGISTRY_PASSWORD }}
 
     outputs:
-      test-image: ${{ steps.prep.outputs.has-credentials }}
+      test-image: ${{ steps.prep.outputs.test-image }}
       test-arguments: ${{ steps.prep.outputs.test-arguments }}
 
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,12 +15,39 @@ jobs:
     outputs:
       stack-yamls: ${{ steps.generate.outputs.stack-yamls }}
 
+  prep:
+    runs-on: ubuntu-latest
+    steps:
+      - id: prep
+        run: |
+          if [[ -n "$FAKTORY_REGISTRY_USERNAME" && -n "$FAKTORY_REGISTRY_PASSWORD" ]]; then
+            echo "Credentials found, using non-free faktory and running all tests"
+            image=docker.contribsys.com/contribsys/faktory-ent:1.4.0
+            arguments=''
+          else
+            echo "Credentials not found, using free faktory and skipping Faktory.Ent tests"
+            image=contribsys/faktory:1.4.0
+            arguments='--test-arguments="--skip Faktory.Ent"'
+          fi
+
+          echo "test-image=$image" >>"$GITHUB_OUTPUT"
+          echo "test-arguments=$arguments" >>"$GITHUB_OUTPUT"
+        env:
+          FAKTORY_REGISTRY_USERNAME: ${{ secrets.FAKTORY_REGISTRY_USERNAME }}
+          FAKTORY_REGISTRY_PASSWORD: ${{ secrets.FAKTORY_REGISTRY_PASSWORD }}
+
+    outputs:
+      test-image: ${{ steps.prep.outputs.has-credentials }}
+      test-arguments: ${{ steps.prep.outputs.test-arguments }}
+
   test:
-    needs: generate
+    needs:
+      - prep
+      - generate
     runs-on: ubuntu-latest
     services:
       faktory:
-        image: docker.contribsys.com/contribsys/faktory-ent:1.4.0
+        image: ${{ needs.prep.outputs.test-image }}
         credentials:
           username: ${{ secrets.FAKTORY_REGISTRY_USERNAME }}
           password: ${{ secrets.FAKTORY_REGISTRY_PASSWORD }}
@@ -35,6 +62,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: freckle/stack-action@v5
+        with:
+          stack-build-arguments-test: ${{ needs.prep.outputs.test-arguments }}
         env:
           STACK_YAML: ${{ matrix.stack-yaml }}
           FAKTORY_URL: tcp://localhost:7419


### PR DESCRIPTION
Adds a `prep` job that checks to see if the `secrets.FAKTORY` values are
available and, only if so, uses the enterprise image and runs the
`Faktory.Ent` specs. Otherwise, if we use a free image and skip those
tests, then CI works for Dependabot and fork PRs, for example.

We could've solved Dependabot by making the necessary secrets available
in this scope, but it seems good to solve for forks as well.
