### PR TITLE
pin tls

### DIFF
--- a/stack-lts16.yaml
+++ b/stack-lts16.yaml
@@ -6,4 +6,4 @@ extra-deps:
   - crypton-x509-store-1.6.9
   - crypton-x509-system-1.6.7
   - crypton-x509-validation-1.6.12
-  - tls-1.7.0
+  - tls-1.7.0@rev:0

--- a/stack-lts18.yaml
+++ b/stack-lts18.yaml
@@ -6,4 +6,4 @@ extra-deps:
   - crypton-x509-store-1.6.9
   - crypton-x509-system-1.6.7
   - crypton-x509-validation-1.6.12
-  - tls-1.7.0
+  - tls-1.7.0@rev:0

--- a/stack-lts19.yaml
+++ b/stack-lts19.yaml
@@ -6,4 +6,4 @@ extra-deps:
   - crypton-x509-store-1.6.9
   - crypton-x509-system-1.6.7
   - crypton-x509-validation-1.6.12
-  - tls-1.7.0
+  - tls-1.7.0@rev:0

--- a/stack-lts20.yaml
+++ b/stack-lts20.yaml
@@ -6,4 +6,4 @@ extra-deps:
   - crypton-x509-store-1.6.9
   - crypton-x509-system-1.6.7
   - crypton-x509-validation-1.6.12
-  - tls-1.7.0
+  - tls-1.7.0@rev:0

--- a/stack-lts21.yaml
+++ b/stack-lts21.yaml
@@ -7,4 +7,4 @@ extra-deps:
   - crypton-x509-store-1.6.9
   - crypton-x509-system-1.6.7
   - crypton-x509-validation-1.6.12
-  - tls-1.7.0
+  - tls-1.7.0@rev:0


### PR DESCRIPTION
Regarding https://github.com/freckle/faktory_worker_haskell/pull/121#issuecomment-3184479227

I think my opinion here is: When listing something in extra-deps, you should always include revision number. The revision simply should be considered part of a release's version number, and I'm perpetually angry at tools that make it seem like it isn't. By not specifying the revision, we're essentially wildcarding the version. Putting `tls-1.7.0` in `extra-deps` is a dumb thing to do for the same reason you wouldn't write `tls-1.*` (if that's even supported, I don't know); it's incomplete. It should have been `tls-1.7.0@rev:0` from the beginning, because anything else is ambiguous.

I still think committing lock files for libraries is overkill; it's only important if you _really_ don't trust Hackage not to swap in a different contents for a _fully_ qualified version number.

It doesn't seem worth it to go back and likewise fix the revisions of everything else that's already in `extra-deps`, but my thought is that we should do it for new dependency overrides going forward.