### PR TITLE
Move markdown-unlit to build-tools

### DIFF
--- a/README.lhs
+++ b/README.lhs
@@ -56,7 +56,6 @@ import Faktory.Producer
 import Faktory.Job
 import Faktory.Worker
 import GHC.Generics
-import Text.Markdown.Unlit ()
 
 {- Don't actually run anything -}
 main :: IO ()

--- a/faktory.cabal
+++ b/faktory.cabal
@@ -1,10 +1,10 @@
 cabal-version: 1.18
 
--- This file has been generated from package.yaml by hpack version 0.37.0.
+-- This file has been generated from package.yaml by hpack version 0.38.1.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: a4d646a21cff8fc33537d6d4e1a120dcf25903423386e51b03c2ca17cfec9dc5
+-- hash: 13c6f45bbc8d8b57afa10fd0df966bb6301c67cdf95525f31b2e2243c0e7acd3
 
 name:           faktory
 version:        1.1.3.2
@@ -312,11 +312,12 @@ test-suite readme
       TypeApplications
       TypeFamilies
   ghc-options: -Weverything -Wno-missing-exported-signatures -Wno-missed-specialisations -Wno-all-missed-specialisations -Wno-unsafe -Wno-safe -Wno-missing-local-signatures -Wno-monomorphism-restriction -Wno-missing-import-lists -pgmL markdown-unlit
+  build-tool-depends:
+      markdown-unlit:markdown-unlit
   build-depends:
       aeson
     , base ==4.*
     , faktory
-    , markdown-unlit
   default-language: Haskell2010
   if impl(ghc >= 8.10)
     ghc-options: -Wno-missing-safe-haskell-mode -Wno-prepositive-qualified-module

--- a/package.yaml
+++ b/package.yaml
@@ -157,4 +157,5 @@ tests:
     dependencies:
       - aeson
       - faktory
+    build-tools:
       - markdown-unlit


### PR DESCRIPTION
## Summary

This PR moves `markdown-unlit` from `dependencies` to `build-tools` in the package.yaml test configuration and removes the corresponding empty import from README.lhs.

## Why this change?

When `markdown-unlit` is listed in `dependencies`, we need to import it in the Haskell code to avoid unused-package warnings from GHC. However, since `markdown-unlit` is only used as a preprocessor (via `-pgmL markdown-unlit`), we don't actually need to import anything from it in our code.

By moving it to `build-tools` instead, we:
- Avoid unused-package warnings without needing empty imports
- Make the dependency relationship clearer (it's a build tool, not a runtime dependency)
- Follow Stack/Cabal best practices for preprocessor dependencies

## Changes

- Moved `markdown-unlit` from `dependencies` to `build-tools` in package.yaml
- Removed `import Text.Markdown.Unlit ()` from README.lhs
- Regenerated any files via `stack build --fast --test --no-run-tests`

🤖 Generated with Claude Code