### PR TITLE
Fix STACK_YAML used in release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,4 +17,4 @@ jobs:
         run: stack upload --pvp-bounds lower .
         env:
           HACKAGE_KEY: ${{ secrets.HACKAGE_UPLOAD_API_KEY }}
-          STACK_YAML: stack-lts16.yaml
+          STACK_YAML: stack-lts21.yaml


### PR DESCRIPTION
I have never not adjusted the resolvers without forgetting this step. It
almost makes me want to go back to our custom release action, which
served no purpose except dynamically inferring the lowest resolver.
