### PR TITLE
Add test-ent to allowed-skips

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,3 +104,4 @@ jobs:
       - uses: re-actors/alls-green@release/v1
         with:
           jobs: ${{ toJSON(needs) }}
+          allowed-skips: test-ent


### PR DESCRIPTION
This job is skipped for a few reasons:

1. It's a Dependabot PR (no secrets)
2. It's a fork PR (no secrets)
3. On the `push` event (incidental, because of how the conditions for 1
   and 2 are written to expect PR events)

We need to ensure `check` doesn't fail in these cases, which is what
`allowed-skips` is for. So far, we had not encountered (1) or (2) since
adding `checks` and `alls-green`, so we didn't realize. But seeing a
failure email for (3) clued me in.
